### PR TITLE
PKI: Return an empty buffer instead of null when Vault returns 204

### DIFF
--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultPKIITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultPKIITCase.java
@@ -915,6 +915,9 @@ public class VaultPKIITCase {
         GeneratedRootCertificate generatedRootCertificate = pkiSecretEngine.generateRoot(genRootOptions);
         assertNotNull(generatedRootCertificate.certificate);
 
+        // Ensure root CA's returns empty CA chain
+        assertTrue(pkiSecretEngine.getCertificateAuthorityChain().getCertificates().isEmpty());
+
         // Generate intermediate CA CSR in "pki2"
         VaultPKISecretEngine pkiSecretEngine2 = pkiSecretEngineFactory.engine("pki2");
 

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalPKISecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalPKISecretEngine.java
@@ -50,7 +50,8 @@ public class VaultInternalPKISecretEngine extends VaultInternalBase {
 
     private Buffer getRaw(String token, String mount, String path, String format) {
         String suffix = format != null ? "/" + format : "";
-        return vaultClient.get(getPath(mount, path + suffix), token);
+        Buffer result = vaultClient.get(getPath(mount, path + suffix), token);
+        return result != null ? result : Buffer.buffer();
     }
 
     public VaultPKICertificateResult getCertificate(String token, String mount, String serial) {


### PR DESCRIPTION
This only applies to the `VaultInternalPKISecretEngine.getRaw`. Previously when fetching an empty CA Chain or CRL it would thow a NPE, now it returns an empty list.