### PR TITLE
Disable the async DNS resolver when starting the Vert.x instance

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.7.0.Final
+:quarkus-version: 2.7.1.Final
 :quarkus-vault-version: 1.0.1
 :maven-version: 3.8.1+
 


### PR DESCRIPTION
The async DNS resolver can cause an issue when resolving the Vault server IP.
The blocking DNS is safest in this case, especially because we don't care about blocking as it is only happening during the application startup. 

Fix #21
