### PR TITLE
Support GET sys/mounts/:path

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 2.7.1.Final
+:quarkus-version: 2.8.0.Final
 :quarkus-vault-version: 1.0.2
 :maven-version: 3.8.1+
 

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultSecretEngineInfoData.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultSecretEngineInfoData.java
@@ -1,0 +1,22 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class VaultSecretEngineInfoData {
+
+    public String description;
+
+    @JsonProperty("external_entropy_access")
+    public Boolean externalEntropyAccess;
+
+    public Boolean local;
+
+    @JsonProperty("seal_wrap")
+    public Boolean sealWrap;
+
+    public String type;
+
+    public Map<String, Object> options;
+}

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultSecretEngineInfoResult.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultSecretEngineInfoResult.java
@@ -1,0 +1,6 @@
+package io.quarkus.vault.runtime.client.dto.sys;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+public class VaultSecretEngineInfoResult extends AbstractVaultDTO<VaultSecretEngineInfoData, Object> {
+}

--- a/runtime/src/main/java/io/quarkus/vault/VaultSystemBackendEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultSystemBackendEngine.java
@@ -9,6 +9,7 @@ import io.quarkus.vault.sys.VaultHealthStatus;
 import io.quarkus.vault.sys.VaultInit;
 import io.quarkus.vault.sys.VaultSealStatus;
 import io.quarkus.vault.sys.VaultSecretEngine;
+import io.quarkus.vault.sys.VaultSecretEngineInfo;
 import io.quarkus.vault.sys.VaultTuneInfo;
 
 /**
@@ -90,6 +91,17 @@ public interface VaultSystemBackendEngine {
      * @return current tune info
      */
     VaultTuneInfo getTuneInfo(String mount);
+
+    /**
+     * Get the info for a secret engine, including its type.
+     * 
+     * @since Vault 1.10.0
+     * @see https://www.vaultproject.io/api-docs/system/mounts#get-the-configuration-of-a-secret-engine
+     *
+     * @param mount Name of the secret engine
+     * @return current secret engine info
+     */
+    VaultSecretEngineInfo getSecretEngineInfo(String mount);
 
     /**
      * Update the tune info for a secret engine at a specific mount.

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultVersions.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultVersions.java
@@ -2,6 +2,6 @@ package io.quarkus.vault.runtime;
 
 public class VaultVersions {
 
-    public static final String VAULT_TEST_VERSION = "1.7.1";
+    public static final String VAULT_TEST_VERSION = "1.10.0";
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/backend/VaultInternalSystemBackend.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/backend/VaultInternalSystemBackend.java
@@ -19,6 +19,7 @@ import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyBody;
 import io.quarkus.vault.runtime.client.dto.sys.VaultPolicyResult;
 import io.quarkus.vault.runtime.client.dto.sys.VaultRenewLease;
 import io.quarkus.vault.runtime.client.dto.sys.VaultSealStatusResult;
+import io.quarkus.vault.runtime.client.dto.sys.VaultSecretEngineInfoResult;
 import io.quarkus.vault.runtime.client.dto.sys.VaultTuneBody;
 import io.quarkus.vault.runtime.client.dto.sys.VaultTuneResult;
 import io.quarkus.vault.runtime.client.dto.sys.VaultUnwrapBody;
@@ -96,6 +97,10 @@ public class VaultInternalSystemBackend extends VaultInternalBase {
 
     public void updateTuneInfo(String token, String mount, VaultTuneBody body) {
         vaultClient.post("sys/mounts/" + mount + "/tune", token, body, 204);
+    }
+
+    public VaultSecretEngineInfoResult getSecretEngineInfo(String token, String mount) {
+        return vaultClient.get("sys/mounts/" + mount, token, VaultSecretEngineInfoResult.class);
     }
 
     // ---

--- a/runtime/src/main/java/io/quarkus/vault/sys/VaultSecretEngineInfo.java
+++ b/runtime/src/main/java/io/quarkus/vault/sys/VaultSecretEngineInfo.java
@@ -1,0 +1,72 @@
+package io.quarkus.vault.sys;
+
+import java.util.Map;
+
+public class VaultSecretEngineInfo {
+
+    private String description;
+
+    private Boolean externalEntropyAccess;
+
+    private Boolean local;
+
+    private Boolean sealWrap;
+
+    private String type;
+
+    private Map<String, Object> options;
+
+    public Boolean getExternalEntropyAccess() {
+        return externalEntropyAccess;
+    }
+
+    public Boolean getLocal() {
+        return local;
+    }
+
+    public Boolean getSealWrap() {
+        return sealWrap;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Map<String, Object> getOptions() {
+        return options;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public VaultSecretEngineInfo setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public VaultSecretEngineInfo setExternalEntropyAccess(Boolean externalEntropyAccess) {
+        this.externalEntropyAccess = externalEntropyAccess;
+        return this;
+    }
+
+    public VaultSecretEngineInfo setLocal(Boolean local) {
+        this.local = local;
+        return this;
+    }
+
+    public VaultSecretEngineInfo setSealWrap(Boolean sealWrap) {
+        this.sealWrap = sealWrap;
+        return this;
+    }
+
+    public VaultSecretEngineInfo setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public VaultSecretEngineInfo setOptions(Map<String, Object> options) {
+        this.options = options;
+        return this;
+    }
+}

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -182,8 +182,8 @@ public class VaultTestExtension {
         vaultBootstrapConfig.enterprise.namespace = Optional.empty();
         vaultBootstrapConfig.tls.skipVerify = Optional.of(true);
         vaultBootstrapConfig.tls.caCert = Optional.empty();
-        vaultBootstrapConfig.connectTimeout = Duration.ofSeconds(5);
-        vaultBootstrapConfig.readTimeout = Duration.ofSeconds(1);
+        vaultBootstrapConfig.connectTimeout = Duration.ofSeconds(30);
+        vaultBootstrapConfig.readTimeout = Duration.ofSeconds(5);
         vaultBootstrapConfig.nonProxyHosts = Optional.empty();
         vaultBootstrapConfig.authentication = new VaultAuthenticationConfig();
         vaultBootstrapConfig.authentication.kubernetes = new VaultKubernetesAuthenticationConfig();


### PR DESCRIPTION
Implement a new endpoint `getMountInfo(String)` on the `VaultSystemBackendEngine`
Use it in `VaultSystemBackendManager.isEngineMounted(String)` when possible (starting in `1.10`)
Upgrade Vault to `1.10`

See https://github.com/hashicorp/vault/issues/12349
