### PR TITLE
Reorganize to support shared Vertx instance when available

### DIFF
--- a/deployment/src/main/java/io/quarkus/vault/deployment/VaultProcessor.java
+++ b/deployment/src/main/java/io/quarkus/vault/deployment/VaultProcessor.java
@@ -35,7 +35,8 @@ import io.quarkus.vault.runtime.VaultRecorder;
 import io.quarkus.vault.runtime.VaultSystemBackendManager;
 import io.quarkus.vault.runtime.VaultTOTPManager;
 import io.quarkus.vault.runtime.VaultTransitManager;
-import io.quarkus.vault.runtime.client.VertxVaultClient;
+import io.quarkus.vault.runtime.client.PrivateVertxVaultClient;
+import io.quarkus.vault.runtime.client.SharedVertxVaultClient;
 import io.quarkus.vault.runtime.client.authmethod.VaultInternalAppRoleAuthMethod;
 import io.quarkus.vault.runtime.client.authmethod.VaultInternalKubernetesAuthMethod;
 import io.quarkus.vault.runtime.client.authmethod.VaultInternalTokenAuthMethod;
@@ -97,7 +98,8 @@ public class VaultProcessor {
                 .addBeanClass(VaultKubernetesAuthService.class)
                 .addBeanClass(VaultAuthManager.class)
                 .addBeanClass(VaultDynamicCredentialsManager.class)
-                .addBeanClass(VertxVaultClient.class)
+                .addBeanClass(PrivateVertxVaultClient.class)
+                .addBeanClass(SharedVertxVaultClient.class)
                 .addBeanClass(VaultConfigHolder.class)
                 .addBeanClass(VaultPKIManager.class)
                 .addBeanClass(VaultPKISecretEngine.class)

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
@@ -240,8 +240,9 @@ public class VaultTransitITCase {
     }
 
     private void rotate(String keyName) {
-        String clientToken = vaultAuthManager.getClientToken().await().indefinitely();
-        new TestVaultClient().rotate(clientToken, keyName).await().indefinitely();
+        TestVaultClient client = new TestVaultClient();
+        String clientToken = vaultAuthManager.getClientToken(client).await().indefinitely();
+        client.rotate(clientToken, keyName).await().indefinitely();
     }
 
     private String encrypt(int keyVersion) {

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultPKIManagerFactory.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultPKIManagerFactory.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 import io.quarkus.vault.VaultPKISecretEngine;
 import io.quarkus.vault.VaultPKISecretEngineFactory;
 import io.quarkus.vault.VaultPKISecretReactiveEngine;
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.secretengine.VaultInternalPKISecretEngine;
 
 @ApplicationScoped
@@ -13,6 +14,8 @@ public class VaultPKIManagerFactory implements VaultPKISecretEngineFactory {
 
     static final String PKI_ENGINE_NAME = "pki";
 
+    @Inject
+    private VaultClient vaultClient;
     @Inject
     private VaultAuthManager vaultAuthManager;
     @Inject
@@ -25,6 +28,6 @@ public class VaultPKIManagerFactory implements VaultPKISecretEngineFactory {
 
     @Override
     public VaultPKISecretReactiveEngine reactiveEngine(String mount) {
-        return new VaultPKIManager(mount, vaultAuthManager, vaultInternalPKISecretEngine);
+        return new VaultPKIManager(vaultClient, mount, vaultAuthManager, vaultInternalPKISecretEngine);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultRecorder.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultRecorder.java
@@ -4,20 +4,16 @@ import static java.util.Collections.emptyList;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
-import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.vault.runtime.client.VertxVaultClient;
 import io.quarkus.vault.runtime.config.VaultBootstrapConfig;
 import io.quarkus.vault.runtime.config.VaultConfigSourceProvider;
 
 @Recorder
 public class VaultRecorder {
-
-    private static final Logger log = Logger.getLogger(VaultRecorder.class);
 
     private static final EmptyConfigSourceProvider EMPTY = new EmptyConfigSourceProvider();
 
@@ -33,7 +29,6 @@ public class VaultRecorder {
         if (vaultBootstrapConfig.url.isPresent()) {
             ArcContainer container = Arc.container();
             container.instance(VaultConfigHolder.class).get().setVaultBootstrapConfig(vaultBootstrapConfig);
-            container.instance(VertxVaultClient.class).get().init();
             configSourceProvider = new VaultConfigSourceProvider(vaultBootstrapConfig);
         }
         return new RuntimeValue<>(configSourceProvider);

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/Private.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/Private.java
@@ -1,0 +1,20 @@
+package io.quarkus.vault.runtime.client;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Private {
+
+    class Literal extends AnnotationLiteral<Private> implements Private {
+        public static final Literal INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
+
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/PrivateVertxVaultClient.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/PrivateVertxVaultClient.java
@@ -1,0 +1,96 @@
+package io.quarkus.vault.runtime.client;
+
+import static io.quarkus.vault.runtime.client.MutinyVertxClientFactory.createHttpClient;
+import static io.vertx.core.spi.resolver.ResolverProvider.DISABLE_DNS_RESOLVER_PROP_NAME;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Singleton;
+
+import io.quarkus.runtime.TlsConfig;
+import io.quarkus.vault.VaultException;
+import io.quarkus.vault.runtime.VaultConfigHolder;
+import io.vertx.core.VertxOptions;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.ext.web.client.WebClient;
+
+@Singleton
+@Private
+public class PrivateVertxVaultClient extends VertxVaultClient {
+
+    private AtomicReference<Vertx> vertx = new AtomicReference<>();
+    private AtomicReference<WebClient> webClient = new AtomicReference<>();
+    private final TlsConfig tlsConfig;
+    private final VaultConfigHolder vaultConfigHolder;
+
+    public PrivateVertxVaultClient(VaultConfigHolder vaultConfigHolder, TlsConfig tlsConfig) {
+        super(vaultConfigHolder.getVaultBootstrapConfig().url.orElseThrow(() -> new VaultException("no vault url provided")),
+                vaultConfigHolder.getVaultBootstrapConfig().enterprise.namespace,
+                vaultConfigHolder.getVaultBootstrapConfig().readTimeout);
+        this.vaultConfigHolder = vaultConfigHolder;
+        this.tlsConfig = tlsConfig;
+    }
+
+    @Override
+    protected WebClient getWebClient() {
+        WebClient webClient = this.webClient.get();
+        if (webClient == null) {
+            webClient = createHttpClient(getVertx(), vaultConfigHolder.getVaultBootstrapConfig(), tlsConfig);
+            if (!this.webClient.compareAndSet(null, webClient)) {
+                webClient.close();
+                return this.webClient.get();
+            }
+        }
+        return webClient;
+    }
+
+    private Vertx getVertx() {
+        Vertx vertx = this.vertx.get();
+        if (vertx == null) {
+            vertx = createVertxInstance();
+            if (!this.vertx.compareAndSet(null, vertx)) {
+                vertx.close().await().indefinitely();
+                return this.vertx.get();
+            }
+        }
+        return vertx;
+    }
+
+    private Vertx createVertxInstance() {
+        // We must disable the async DNS resolver as it can cause issues when resolving the Vault instance.
+        // This is done using the DISABLE_DNS_RESOLVER_PROP_NAME system property.
+        // The DNS resolver used by vert.x is configured during the (synchronous) initialization.
+        // So, we just need to disable the async resolver around the Vert.x instance creation.
+        String originalValue = System.getProperty(DISABLE_DNS_RESOLVER_PROP_NAME);
+        Vertx vertx;
+        try {
+            System.setProperty(DISABLE_DNS_RESOLVER_PROP_NAME, "true");
+            vertx = Vertx.vertx(new VertxOptions());
+        } finally {
+            // Restore the original value
+            if (originalValue == null) {
+                System.clearProperty(DISABLE_DNS_RESOLVER_PROP_NAME);
+            } else {
+                System.setProperty(DISABLE_DNS_RESOLVER_PROP_NAME, originalValue);
+            }
+        }
+        return vertx;
+    }
+
+    @PreDestroy
+    @Override
+    public void close() {
+        try {
+            WebClient webClient = this.webClient.getAndSet(null);
+            if (webClient != null) {
+                webClient.close();
+            }
+        } finally {
+            Vertx vertx = this.vertx.getAndSet(null);
+            if (vertx != null) {
+                vertx.closeAndAwait();
+            }
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/Shared.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/Shared.java
@@ -1,0 +1,20 @@
+package io.quarkus.vault.runtime.client;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Shared {
+
+    class Literal extends AnnotationLiteral<Shared> implements Shared {
+        public static final Literal INSTANCE = new Literal();
+
+        private Literal() {
+        }
+    }
+
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/SharedVertxVaultClient.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/SharedVertxVaultClient.java
@@ -1,0 +1,60 @@
+package io.quarkus.vault.runtime.client;
+
+import static io.quarkus.vault.runtime.client.MutinyVertxClientFactory.createHttpClient;
+
+import java.lang.annotation.Annotation;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.TlsConfig;
+import io.quarkus.vault.VaultException;
+import io.quarkus.vault.runtime.VaultConfigHolder;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.ext.web.client.WebClient;
+
+@Singleton
+@Shared
+public class SharedVertxVaultClient extends VertxVaultClient {
+
+    @Produces
+    @Dependent
+    public static VertxVaultClient createSharedVaultClient(Instance<Vertx> vertx) {
+        Annotation clientType;
+        if (vertx.isResolvable()) {
+            clientType = Shared.Literal.INSTANCE;
+        } else {
+            clientType = Private.Literal.INSTANCE;
+        }
+        return Arc.container().select(VertxVaultClient.class, clientType).get();
+    }
+
+    private final AtomicReference<WebClient> webClient = new AtomicReference<>();
+
+    public SharedVertxVaultClient(Vertx vertx, VaultConfigHolder vaultConfigHolder, TlsConfig tlsConfig) {
+        super(vaultConfigHolder.getVaultBootstrapConfig().url.orElseThrow(() -> new VaultException("no vault url provided")),
+                vaultConfigHolder.getVaultBootstrapConfig().enterprise.namespace,
+                vaultConfigHolder.getVaultBootstrapConfig().readTimeout);
+        this.webClient.set(createHttpClient(vertx, vaultConfigHolder.getVaultBootstrapConfig(), tlsConfig));
+    }
+
+    @Override
+    protected WebClient getWebClient() {
+        return webClient.get();
+    }
+
+    @PreDestroy
+    @Override
+    public void close() {
+        WebClient webClient = this.webClient.getAndSet(null);
+        if (webClient != null) {
+            webClient.close();
+        }
+    }
+
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClient.java
@@ -11,33 +11,34 @@ public interface VaultClient {
     String X_VAULT_NAMESPACE = "X-Vault-Namespace";
     String API_VERSION = "v1";
 
-    <T> Uni<T> put(String path, String token, Object body, int expectedCode);
+    <T> Uni<T> put(String operation, String path, String token, Object body, int expectedCode);
 
-    <T> Uni<T> list(String path, String token, Class<T> resultClass);
+    <T> Uni<T> list(String operation, String path, String token, Class<T> resultClass);
 
-    <T> Uni<T> delete(String path, String token, int expectedCode);
+    <T> Uni<T> delete(String operation, String path, String token, int expectedCode);
 
-    <T> Uni<T> post(String path, String token, Object body, Class<T> resultClass, int expectedCode);
+    <T> Uni<T> post(String operation, String path, String token, Object body, Class<T> resultClass, int expectedCode);
 
-    <T> Uni<T> post(String path, String token, Object body, Class<T> resultClass);
+    <T> Uni<T> post(String operation, String path, String token, Object body, Class<T> resultClass);
 
-    <T> Uni<T> post(String path, String token, Map<String, String> headers, Object body, Class<T> resultClass);
+    <T> Uni<T> post(String operation, String path, String token, Map<String, String> headers, Object body,
+            Class<T> resultClass);
 
-    <T> Uni<T> post(String path, String token, Object body, int expectedCode);
+    <T> Uni<T> post(String operation, String path, String token, Object body, int expectedCode);
 
-    <T> Uni<T> put(String path, String token, Object body, Class<T> resultClass);
+    <T> Uni<T> put(String operation, String path, String token, Object body, Class<T> resultClass);
 
-    <T> Uni<T> put(String path, Object body, Class<T> resultClass);
+    <T> Uni<T> put(String operation, String path, Object body, Class<T> resultClass);
 
-    <T> Uni<T> get(String path, String token, Class<T> resultClass);
+    <T> Uni<T> get(String operation, String path, String token, Class<T> resultClass);
 
-    <T> Uni<T> get(String path, Map<String, String> queryParams, Class<T> resultClass);
+    <T> Uni<T> get(String operation, String path, Map<String, String> queryParams, Class<T> resultClass);
 
-    Uni<Buffer> get(String path, String token);
+    Uni<Buffer> get(String operation, String path, String token);
 
-    Uni<Integer> head(String path);
+    Uni<Integer> head(String operation, String path);
 
-    Uni<Integer> head(String path, Map<String, String> queryParams);
+    Uni<Integer> head(String operation, String path, Map<String, String> queryParams);
 
-    Uni<Void> close();
+    void close();
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultInternalBase.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultInternalBase.java
@@ -1,14 +1,13 @@
 package io.quarkus.vault.runtime.client;
 
-import javax.inject.Inject;
-
 public abstract class VaultInternalBase {
 
-    @Inject
-    protected VaultClient vaultClient;
-
-    public VaultInternalBase setVaultClient(VaultClient vaultClient) {
-        this.vaultClient = vaultClient;
-        return this;
+    protected String opNamePrefix() {
+        return "VAULT";
     }
+
+    protected String opName(String name) {
+        return opNamePrefix() + " " + name;
+    }
+
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAppRoleAuthMethod.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAppRoleAuthMethod.java
@@ -2,6 +2,7 @@ package io.quarkus.vault.runtime.client.authmethod;
 
 import javax.inject.Singleton;
 
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultAppRoleAuthBody;
@@ -10,8 +11,13 @@ import io.smallrye.mutiny.Uni;
 @Singleton
 public class VaultInternalAppRoleAuthMethod extends VaultInternalBase {
 
-    public Uni<VaultAppRoleAuth> login(String roleId, String secretId) {
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [AUTH (approle)]";
+    }
+
+    public Uni<VaultAppRoleAuth> login(VaultClient vaultClient, String roleId, String secretId) {
         VaultAppRoleAuthBody body = new VaultAppRoleAuthBody(roleId, secretId);
-        return vaultClient.post("auth/approle/login", null, body, VaultAppRoleAuth.class);
+        return vaultClient.post(opName("Login"), "auth/approle/login", null, body, VaultAppRoleAuth.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalKubernetesAuthMethod.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalKubernetesAuthMethod.java
@@ -4,6 +4,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import io.quarkus.vault.runtime.VaultConfigHolder;
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultKubernetesAuthBody;
@@ -24,37 +25,41 @@ public class VaultInternalKubernetesAuthMethod extends VaultInternalBase {
         return vaultConfigHolder.getVaultBootstrapConfig().authentication.kubernetes.authMountPath;
     }
 
-    public Uni<VaultKubernetesAuth> login(String role, String jwt) {
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [AUTH (k8s)]";
+    }
+
+    public Uni<VaultKubernetesAuth> login(VaultClient vaultClient, String role, String jwt) {
         VaultKubernetesAuthBody body = new VaultKubernetesAuthBody(role, jwt);
-        return vaultClient.post(getKubernetesAuthMountPath() + "/login", null, body, VaultKubernetesAuth.class);
+        return vaultClient.post(opName("Login"), getKubernetesAuthMountPath() + "/login", null, body,
+                VaultKubernetesAuth.class);
     }
 
-    public Uni<Void> createAuthRole(String token, String name, VaultKubernetesAuthRoleData body) {
-        return vaultClient.post(getKubernetesAuthMountPath() + "/role/" + name, token, body, 204);
+    public Uni<Void> createAuthRole(VaultClient vaultClient, String token, String name, VaultKubernetesAuthRoleData body) {
+        return vaultClient.post(opName("Create Role"), getKubernetesAuthMountPath() + "/role/" + name, token, body, 204);
     }
 
-    public Uni<VaultKubernetesAuthReadRoleResult> getVaultAuthRole(String token, String name) {
-        return vaultClient.get(getKubernetesAuthMountPath() + "/role/" + name, token, VaultKubernetesAuthReadRoleResult.class);
+    public Uni<VaultKubernetesAuthReadRoleResult> getVaultAuthRole(VaultClient vaultClient, String token, String name) {
+        return vaultClient.get(opName("Get Role"), getKubernetesAuthMountPath() + "/role/" + name, token,
+                VaultKubernetesAuthReadRoleResult.class);
     }
 
-    public Uni<VaultKubernetesAuthListRolesResult> listAuthRoles(String token) {
-        return vaultClient.list(getKubernetesAuthMountPath() + "/role", token, VaultKubernetesAuthListRolesResult.class);
+    public Uni<VaultKubernetesAuthListRolesResult> listAuthRoles(VaultClient vaultClient, String token) {
+        return vaultClient.list(opName("List Roles"), getKubernetesAuthMountPath() + "/role", token,
+                VaultKubernetesAuthListRolesResult.class);
     }
 
-    public Uni<Void> deleteAuthRoles(String token, String name) {
-        return vaultClient.delete(getKubernetesAuthMountPath() + "/role/" + name, token, 204);
+    public Uni<Void> deleteAuthRoles(VaultClient vaultClient, String token, String name) {
+        return vaultClient.delete(opName("Delete Role"), getKubernetesAuthMountPath() + "/role/" + name, token, 204);
     }
 
-    public Uni<Void> configureAuth(String token, VaultKubernetesAuthConfigData config) {
-        return vaultClient.post(getKubernetesAuthMountPath() + "/config", token, config, 204);
+    public Uni<Void> configureAuth(VaultClient vaultClient, String token, VaultKubernetesAuthConfigData config) {
+        return vaultClient.post(opName("Configure"), getKubernetesAuthMountPath() + "/config", token, config, 204);
     }
 
-    public Uni<VaultKubernetesAuthConfigResult> readAuthConfig(String token) {
-        return vaultClient.get(getKubernetesAuthMountPath() + "/config", token, VaultKubernetesAuthConfigResult.class);
-    }
-
-    public VaultInternalKubernetesAuthMethod setVaultConfigHolder(VaultConfigHolder vaultConfigHolder) {
-        this.vaultConfigHolder = vaultConfigHolder;
-        return this;
+    public Uni<VaultKubernetesAuthConfigResult> readAuthConfig(VaultClient vaultClient, String token) {
+        return vaultClient.get(opName("Read Configuration"), getKubernetesAuthMountPath() + "/config", token,
+                VaultKubernetesAuthConfigResult.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalTokenAuthMethod.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalTokenAuthMethod.java
@@ -2,6 +2,7 @@ package io.quarkus.vault.runtime.client.authmethod;
 
 import javax.inject.Singleton;
 
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.auth.VaultLookupSelf;
 import io.quarkus.vault.runtime.client.dto.auth.VaultRenewSelf;
@@ -11,12 +12,17 @@ import io.smallrye.mutiny.Uni;
 @Singleton
 public class VaultInternalTokenAuthMethod extends VaultInternalBase {
 
-    public Uni<VaultRenewSelf> renewSelf(String token, String increment) {
-        VaultRenewSelfBody body = new VaultRenewSelfBody(increment);
-        return vaultClient.post("auth/token/renew-self", token, body, VaultRenewSelf.class);
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [AUTH (token)]";
     }
 
-    public Uni<VaultLookupSelf> lookupSelf(String token) {
-        return vaultClient.get("auth/token/lookup-self", token, VaultLookupSelf.class);
+    public Uni<VaultRenewSelf> renewSelf(VaultClient vaultClient, String token, String increment) {
+        VaultRenewSelfBody body = new VaultRenewSelfBody(increment);
+        return vaultClient.post(opName("Renew Self"), "auth/token/renew-self", token, body, VaultRenewSelf.class);
+    }
+
+    public Uni<VaultLookupSelf> lookupSelf(VaultClient vaultClient, String token) {
+        return vaultClient.get(opName("Lookup Self"), "auth/token/lookup-self", token, VaultLookupSelf.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalUserpassAuthMethod.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalUserpassAuthMethod.java
@@ -2,6 +2,7 @@ package io.quarkus.vault.runtime.client.authmethod;
 
 import javax.inject.Singleton;
 
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.auth.VaultUserPassAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultUserPassAuthBody;
@@ -10,8 +11,13 @@ import io.smallrye.mutiny.Uni;
 @Singleton
 public class VaultInternalUserpassAuthMethod extends VaultInternalBase {
 
-    public Uni<VaultUserPassAuth> login(String user, String password) {
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [AUTH (user/pass)]";
+    }
+
+    public Uni<VaultUserPassAuth> login(VaultClient vaultClient, String user, String password) {
         VaultUserPassAuthBody body = new VaultUserPassAuthBody(password);
-        return vaultClient.post("auth/userpass/login/" + user, null, body, VaultUserPassAuth.class);
+        return vaultClient.post(opName("Login"), "auth/userpass/login/" + user, null, body, VaultUserPassAuth.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalDynamicCredentialsSecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalDynamicCredentialsSecretEngine.java
@@ -2,6 +2,7 @@ package io.quarkus.vault.runtime.client.secretengine;
 
 import javax.inject.Singleton;
 
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.dynamic.VaultDynamicCredentials;
 import io.smallrye.mutiny.Uni;
@@ -9,7 +10,14 @@ import io.smallrye.mutiny.Uni;
 @Singleton
 public class VaultInternalDynamicCredentialsSecretEngine extends VaultInternalBase {
 
-    public Uni<VaultDynamicCredentials> generateCredentials(String token, String mount, String requestPath, String role) {
-        return vaultClient.get(mount + "/" + requestPath + "/" + role, token, VaultDynamicCredentials.class);
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [CREDENTIALS]";
+    }
+
+    public Uni<VaultDynamicCredentials> generateCredentials(VaultClient vaultClient, String token, String mount,
+            String requestPath, String role) {
+        return vaultClient.get(opName("Generate"), mount + "/" + requestPath + "/" + role, token,
+                VaultDynamicCredentials.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalKvV1SecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalKvV1SecretEngine.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import javax.inject.Singleton;
 
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.kv.VaultKvListSecrets;
 import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV1;
@@ -12,19 +13,25 @@ import io.smallrye.mutiny.Uni;
 @Singleton
 public class VaultInternalKvV1SecretEngine extends VaultInternalBase {
 
-    public Uni<Void> deleteSecret(String token, String secretEnginePath, String path) {
-        return vaultClient.delete(secretEnginePath + "/" + path, token, 204);
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [KV (v1)]";
     }
 
-    public Uni<Void> writeSecret(String token, String secretEnginePath, String path, Map<String, String> secret) {
-        return vaultClient.post(secretEnginePath + "/" + path, token, secret, null, 204);
+    public Uni<Void> deleteSecret(VaultClient vaultClient, String token, String secretEnginePath, String path) {
+        return vaultClient.delete(opName("Delete Secret"), secretEnginePath + "/" + path, token, 204);
     }
 
-    public Uni<VaultKvSecretV1> getSecret(String token, String secretEnginePath, String path) {
-        return vaultClient.get(secretEnginePath + "/" + path, token, VaultKvSecretV1.class);
+    public Uni<Void> writeSecret(VaultClient vaultClient, String token, String secretEnginePath, String path,
+            Map<String, String> secret) {
+        return vaultClient.post(opName("Write Secret"), secretEnginePath + "/" + path, token, secret, null, 204);
     }
 
-    public Uni<VaultKvListSecrets> listSecrets(String token, String secretEnginePath, String path) {
-        return vaultClient.list(secretEnginePath + "/" + path, token, VaultKvListSecrets.class);
+    public Uni<VaultKvSecretV1> getSecret(VaultClient vaultClient, String token, String secretEnginePath, String path) {
+        return vaultClient.get(opName("Get Secret"), secretEnginePath + "/" + path, token, VaultKvSecretV1.class);
+    }
+
+    public Uni<VaultKvListSecrets> listSecrets(VaultClient vaultClient, String token, String secretEnginePath, String path) {
+        return vaultClient.list(opName("List Secrets"), secretEnginePath + "/" + path, token, VaultKvListSecrets.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalKvV2SecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalKvV2SecretEngine.java
@@ -2,6 +2,7 @@ package io.quarkus.vault.runtime.client.secretengine;
 
 import javax.inject.Singleton;
 
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.kv.VaultKvListSecrets;
 import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2;
@@ -12,20 +13,28 @@ import io.smallrye.mutiny.Uni;
 @Singleton
 public class VaultInternalKvV2SecretEngine extends VaultInternalBase {
 
-    public Uni<VaultKvSecretV2> getSecret(String token, String secretEnginePath, String path) {
-        return vaultClient.get(secretEnginePath + "/data/" + path, token, VaultKvSecretV2.class);
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [KV (v2)]";
     }
 
-    public Uni<Void> writeSecret(String token, String secretEnginePath, String path, VaultKvSecretV2WriteBody body) {
-        return vaultClient.post(secretEnginePath + "/data/" + path, token, body, VaultKvSecretV2Write.class)
+    public Uni<VaultKvSecretV2> getSecret(VaultClient vaultClient, String token, String secretEnginePath, String path) {
+        return vaultClient.get(opName("Get Secret"), secretEnginePath + "/data/" + path, token, VaultKvSecretV2.class);
+    }
+
+    public Uni<Void> writeSecret(VaultClient vaultClient, String token, String secretEnginePath, String path,
+            VaultKvSecretV2WriteBody body) {
+        return vaultClient
+                .post(opName("Write Secret"), secretEnginePath + "/data/" + path, token, body, VaultKvSecretV2Write.class)
                 .replaceWithVoid();
     }
 
-    public Uni<Void> deleteSecret(String token, String secretEnginePath, String path) {
-        return vaultClient.delete(secretEnginePath + "/data/" + path, token, 204);
+    public Uni<Void> deleteSecret(VaultClient vaultClient, String token, String secretEnginePath, String path) {
+        return vaultClient.delete(opName("Delete Secret"), secretEnginePath + "/data/" + path, token, 204);
     }
 
-    public Uni<VaultKvListSecrets> listSecrets(String token, String secretEnginePath, String path) {
-        return vaultClient.list(secretEnginePath + "/metadata/" + path, token, VaultKvListSecrets.class);
+    public Uni<VaultKvListSecrets> listSecrets(VaultClient vaultClient, String token, String secretEnginePath, String path) {
+        return vaultClient.list(opName("List Secrets"), secretEnginePath + "/metadata/" + path, token,
+                VaultKvListSecrets.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalPKISecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalPKISecretEngine.java
@@ -2,6 +2,7 @@ package io.quarkus.vault.runtime.client.secretengine;
 
 import javax.inject.Singleton;
 
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.pki.VaultPKICRLRotateResult;
 import io.quarkus.vault.runtime.client.dto.pki.VaultPKICertificateListResult;
@@ -33,127 +34,146 @@ import io.vertx.mutiny.core.buffer.Buffer;
 @Singleton
 public class VaultInternalPKISecretEngine extends VaultInternalBase {
 
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [PKI]";
+    }
+
     private String getPath(String mount, String path) {
         return mount + "/" + path;
     }
 
-    public Uni<Buffer> getCertificateAuthority(String token, String mount, String format) {
-        return getRaw(token, mount, "ca", format);
+    public Uni<Buffer> getCertificateAuthority(VaultClient vaultClient, String token, String mount, String format) {
+        return getRaw(vaultClient, opName("Get CA"), token, mount, "ca", format);
     }
 
-    public Uni<Buffer> getCertificateRevocationList(String token, String mount, String format) {
-        return getRaw(token, mount, "crl", format);
+    public Uni<Buffer> getCertificateRevocationList(VaultClient vaultClient, String token, String mount, String format) {
+        return getRaw(vaultClient, opName("Get CRL"), token, mount, "crl", format);
     }
 
-    public Uni<Buffer> getCertificateAuthorityChain(String token, String mount) {
-        return getRaw(token, mount, "ca_chain", null);
+    public Uni<Buffer> getCertificateAuthorityChain(VaultClient vaultClient, String token, String mount) {
+        return getRaw(vaultClient, opName("Get CA Chain"), token, mount, "ca_chain", null);
     }
 
-    private Uni<Buffer> getRaw(String token, String mount, String path, String format) {
+    private Uni<Buffer> getRaw(VaultClient vaultClient, String operationName, String token, String mount, String path,
+            String format) {
         String suffix = format != null ? "/" + format : "";
-        return vaultClient.get(getPath(mount, path + suffix), token)
+        return vaultClient.get(operationName, getPath(mount, path + suffix), token)
                 .replaceIfNullWith(Buffer.buffer());
     }
 
-    public Uni<VaultPKICertificateResult> getCertificate(String token, String mount, String serial) {
-        return vaultClient.get(getPath(mount, "cert/" + serial), token, VaultPKICertificateResult.class);
+    public Uni<VaultPKICertificateResult> getCertificate(VaultClient vaultClient, String token, String mount, String serial) {
+        return vaultClient.get(opName("Get Certificate"), getPath(mount, "cert/" + serial), token,
+                VaultPKICertificateResult.class);
     }
 
-    public Uni<VaultPKICertificateListResult> listCertificates(String token, String mount) {
-        return vaultClient.list(getPath(mount, "certs"), token, VaultPKICertificateListResult.class);
+    public Uni<VaultPKICertificateListResult> listCertificates(VaultClient vaultClient, String token, String mount) {
+        return vaultClient.list(opName("List Certificates"), getPath(mount, "certs"), token,
+                VaultPKICertificateListResult.class);
     }
 
-    public Uni<Void> configCertificateAuthority(String token, String mount, VaultPKIConfigCABody body) {
-        return vaultClient.post(getPath(mount, "config/ca"), token, body, 204);
+    public Uni<Void> configCertificateAuthority(VaultClient vaultClient, String token, String mount,
+            VaultPKIConfigCABody body) {
+        return vaultClient.post(opName("Configure CA"), getPath(mount, "config/ca"), token, body, 204);
     }
 
-    public Uni<VaultPKICRLRotateResult> rotateCertificateRevocationList(String token, String mount) {
-        return vaultClient.get(getPath(mount, "crl/rotate"), token, VaultPKICRLRotateResult.class);
+    public Uni<VaultPKICRLRotateResult> rotateCertificateRevocationList(VaultClient vaultClient, String token, String mount) {
+        return vaultClient.get(opName("Rotate CRL"), getPath(mount, "crl/rotate"), token, VaultPKICRLRotateResult.class);
     }
 
     public Uni<VaultPKIGenerateCertificateResult> generateCertificate(
+            VaultClient vaultClient,
             String token,
             String mount,
             String role,
             VaultPKIGenerateCertificateBody body) {
-        return vaultClient.post(getPath(mount, "issue/" + role), token, body, VaultPKIGenerateCertificateResult.class);
+        return vaultClient.post(opName("Issue Certificate"), getPath(mount, "issue/" + role), token, body,
+                VaultPKIGenerateCertificateResult.class);
     }
 
     public Uni<VaultPKISignCertificateRequestResult> signCertificate(
+            VaultClient vaultClient,
             String token,
             String mount,
             String role,
             VaultPKISignCertificateRequestBody body) {
-        return vaultClient.post(getPath(mount, "sign/" + role), token, body, VaultPKISignCertificateRequestResult.class);
+        return vaultClient.post(opName("Sign Certificate"), getPath(mount, "sign/" + role), token, body,
+                VaultPKISignCertificateRequestResult.class);
     }
 
-    public Uni<VaultPKIRevokeCertificateResult> revokeCertificate(String token, String mount,
+    public Uni<VaultPKIRevokeCertificateResult> revokeCertificate(VaultClient vaultClient, String token, String mount,
             VaultPKIRevokeCertificateBody body) {
-        return vaultClient.post(getPath(mount, "revoke"), token, body, VaultPKIRevokeCertificateResult.class);
+        return vaultClient.post(opName("Revoke Certificate"), getPath(mount, "revoke"), token, body,
+                VaultPKIRevokeCertificateResult.class);
     }
 
-    public Uni<Void> updateRole(String token, String mount, String role, VaultPKIRoleOptionsData body) {
-        return vaultClient.post(getPath(mount, "roles/" + role), token, body, 204);
+    public Uni<Void> updateRole(VaultClient vaultClient, String token, String mount, String role,
+            VaultPKIRoleOptionsData body) {
+        return vaultClient.post(opName("Update Role"), getPath(mount, "roles/" + role), token, body, 204);
     }
 
-    public Uni<VaultPKIRoleReadResult> readRole(String token, String mount, String role) {
-        return vaultClient.get(getPath(mount, "roles/" + role), token, VaultPKIRoleReadResult.class);
+    public Uni<VaultPKIRoleReadResult> readRole(VaultClient vaultClient, String token, String mount, String role) {
+        return vaultClient.get(opName("Read Role"), getPath(mount, "roles/" + role), token, VaultPKIRoleReadResult.class);
     }
 
-    public Uni<VaultPKIRolesListResult> listRoles(String token, String mount) {
-        return vaultClient.list(getPath(mount, "roles"), token, VaultPKIRolesListResult.class);
+    public Uni<VaultPKIRolesListResult> listRoles(VaultClient vaultClient, String token, String mount) {
+        return vaultClient.list(opName("List Roles"), getPath(mount, "roles"), token, VaultPKIRolesListResult.class);
     }
 
-    public Uni<Void> deleteRole(String token, String mount, String role) {
-        return vaultClient.delete(getPath(mount, "roles/" + role), token, 204);
+    public Uni<Void> deleteRole(VaultClient vaultClient, String token, String mount, String role) {
+        return vaultClient.delete(opName("Delete Role"), getPath(mount, "roles/" + role), token, 204);
     }
 
-    public Uni<VaultPKIGenerateRootResult> generateRoot(String token, String mount, String type,
+    public Uni<VaultPKIGenerateRootResult> generateRoot(VaultClient vaultClient, String token, String mount, String type,
             VaultPKIGenerateRootBody body) {
-        return vaultClient.post(getPath(mount, "root/generate/" + type), token, body, VaultPKIGenerateRootResult.class);
+        return vaultClient.post(opName("Generate Root CA"), getPath(mount, "root/generate/" + type), token, body,
+                VaultPKIGenerateRootResult.class);
     }
 
-    public Uni<Void> deleteRoot(String token, String mount) {
-        return vaultClient.delete(getPath(mount, "root"), token, 204);
+    public Uni<Void> deleteRoot(VaultClient vaultClient, String token, String mount) {
+        return vaultClient.delete(opName("Delete Root CA"), getPath(mount, "root"), token, 204);
     }
 
-    public Uni<VaultPKISignCertificateRequestResult> signIntermediateCA(String token, String mount,
+    public Uni<VaultPKISignCertificateRequestResult> signIntermediateCA(VaultClient vaultClient, String token, String mount,
             VaultPKISignIntermediateCABody body) {
-        return vaultClient.post(getPath(mount, "root/sign-intermediate"),
+        return vaultClient.post(opName("Sign Intermediate CA"), getPath(mount, "root/sign-intermediate"),
                 token,
                 body,
                 VaultPKISignCertificateRequestResult.class);
     }
 
-    public Uni<VaultPKIGenerateIntermediateCSRResult> generateIntermediateCSR(String token, String mount, String type,
+    public Uni<VaultPKIGenerateIntermediateCSRResult> generateIntermediateCSR(VaultClient vaultClient, String token,
+            String mount, String type,
             VaultPKIGenerateIntermediateCSRBody body) {
-        return vaultClient.post(getPath(mount, "intermediate/generate/" + type),
+        return vaultClient.post(opName("Generate Intermediate CSR"), getPath(mount, "intermediate/generate/" + type),
                 token,
                 body,
                 VaultPKIGenerateIntermediateCSRResult.class);
     }
 
-    public Uni<Void> setSignedIntermediateCA(String token, String mount, VaultPKISetSignedIntermediateCABody body) {
-        return vaultClient.post(getPath(mount, "intermediate/set-signed"), token, body, 204);
+    public Uni<Void> setSignedIntermediateCA(VaultClient vaultClient, String token, String mount,
+            VaultPKISetSignedIntermediateCABody body) {
+        return vaultClient.post(opName("Update Signed Intermediate CA"), getPath(mount, "intermediate/set-signed"), token, body,
+                204);
     }
 
-    public Uni<Void> tidy(String token, String mount, VaultPKITidyBody body) {
-        return vaultClient.post(getPath(mount, "tidy"), token, body, 202);
+    public Uni<Void> tidy(VaultClient vaultClient, String token, String mount, VaultPKITidyBody body) {
+        return vaultClient.post(opName("Tidy"), getPath(mount, "tidy"), token, body, 202);
     }
 
-    public Uni<Void> configURLs(String token, String mount, VaultPKIConfigURLsData body) {
-        return vaultClient.post(getPath(mount, "config/urls"), token, body, 204);
+    public Uni<Void> configURLs(VaultClient vaultClient, String token, String mount, VaultPKIConfigURLsData body) {
+        return vaultClient.post(opName("Configure URLs"), getPath(mount, "config/urls"), token, body, 204);
     }
 
-    public Uni<VaultPKIConfigURLsResult> readURLs(String token, String mount) {
-        return vaultClient.get(getPath(mount, "config/urls"), token, VaultPKIConfigURLsResult.class);
+    public Uni<VaultPKIConfigURLsResult> readURLs(VaultClient vaultClient, String token, String mount) {
+        return vaultClient.get(opName("Read URLs"), getPath(mount, "config/urls"), token, VaultPKIConfigURLsResult.class);
     }
 
-    public Uni<Void> configCRL(String token, String mount, VaultPKIConfigCRLData body) {
-        return vaultClient.post(getPath(mount, "config/crl"), token, body, 204);
+    public Uni<Void> configCRL(VaultClient vaultClient, String token, String mount, VaultPKIConfigCRLData body) {
+        return vaultClient.post(opName("Configure CRL"), getPath(mount, "config/crl"), token, body, 204);
     }
 
-    public Uni<VaultPKIConfigCRLResult> readCRL(String token, String mount) {
-        return vaultClient.get(getPath(mount, "config/crl"), token, VaultPKIConfigCRLResult.class);
+    public Uni<VaultPKIConfigCRLResult> readCRL(VaultClient vaultClient, String token, String mount) {
+        return vaultClient.get(opName("Read CRL"), getPath(mount, "config/crl"), token, VaultPKIConfigCRLResult.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalTOPTSecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalTOPTSecretEngine.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import javax.inject.Singleton;
 
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyBody;
 import io.quarkus.vault.runtime.client.dto.totp.VaultTOTPCreateKeyResult;
@@ -17,41 +18,48 @@ import io.smallrye.mutiny.Uni;
 @Singleton
 public class VaultInternalTOPTSecretEngine extends VaultInternalBase {
 
-    public Uni<Optional<VaultTOTPCreateKeyResult>> createTOTPKey(String token, String keyName, VaultTOTPCreateKeyBody body) {
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [TOTP]";
+    }
+
+    public Uni<Optional<VaultTOTPCreateKeyResult>> createTOTPKey(VaultClient vaultClient, String token, String keyName,
+            VaultTOTPCreateKeyBody body) {
         String path = "totp/keys/" + keyName;
 
         // Depending on parameters it might produce an output or not
         if (body.isProducingOutput()) {
-            return vaultClient.post(path, token, body, VaultTOTPCreateKeyResult.class, 200)
+            return vaultClient.post(opName("Create Key"), path, token, body, VaultTOTPCreateKeyResult.class, 200)
                     .map(Optional::of);
         } else {
-            return vaultClient.post(path, token, body, 204)
+            return vaultClient.post(opName("Create Key"), path, token, body, 204)
                     .map(v -> Optional.empty());
         }
     }
 
-    public Uni<VaultTOTPReadKeyResult> readTOTPKey(String token, String keyName) {
+    public Uni<VaultTOTPReadKeyResult> readTOTPKey(VaultClient vaultClient, String token, String keyName) {
         String path = "totp/keys/" + keyName;
-        return vaultClient.get(path, token, VaultTOTPReadKeyResult.class);
+        return vaultClient.get(opName("Read Key"), path, token, VaultTOTPReadKeyResult.class);
     }
 
-    public Uni<VaultTOTPListKeysResult> listTOTPKeys(String token) {
-        return vaultClient.list("totp/keys", token, VaultTOTPListKeysResult.class);
+    public Uni<VaultTOTPListKeysResult> listTOTPKeys(VaultClient vaultClient, String token) {
+        return vaultClient.list(opName("List Keys"), "totp/keys", token, VaultTOTPListKeysResult.class);
     }
 
-    public Uni<Void> deleteTOTPKey(String token, String keyName) {
+    public Uni<Void> deleteTOTPKey(VaultClient vaultClient, String token, String keyName) {
         String path = "totp/keys/" + keyName;
-        return vaultClient.delete(path, token, 204);
+        return vaultClient.delete(opName("Delete Key"), path, token, 204);
     }
 
-    public Uni<VaultTOTPGenerateCodeResult> generateTOTPCode(String token, String keyName) {
+    public Uni<VaultTOTPGenerateCodeResult> generateTOTPCode(VaultClient vaultClient, String token, String keyName) {
         String path = "totp/code/" + keyName;
-        return vaultClient.get(path, token, VaultTOTPGenerateCodeResult.class);
+        return vaultClient.get(opName("Generate Code"), path, token, VaultTOTPGenerateCodeResult.class);
     }
 
-    public Uni<VaultTOTPValidateCodeResult> validateTOTPCode(String token, String keyName, String code) {
+    public Uni<VaultTOTPValidateCodeResult> validateTOTPCode(VaultClient vaultClient, String token, String keyName,
+            String code) {
         String path = "totp/code/" + keyName;
         VaultTOTPValidateCodeBody body = new VaultTOTPValidateCodeBody(code);
-        return vaultClient.post(path, token, body, VaultTOTPValidateCodeResult.class);
+        return vaultClient.post(opName("Validate Code"), path, token, body, VaultTOTPValidateCodeResult.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalTransitSecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/secretengine/VaultInternalTransitSecretEngine.java
@@ -2,6 +2,7 @@ package io.quarkus.vault.runtime.client.secretengine;
 
 import javax.inject.Singleton;
 
+import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.transit.VaultTransitCreateKeyBody;
 import io.quarkus.vault.runtime.client.dto.transit.VaultTransitDecrypt;
@@ -22,50 +23,61 @@ import io.smallrye.mutiny.Uni;
 @Singleton
 public class VaultInternalTransitSecretEngine extends VaultInternalBase {
 
-    public Uni<Void> updateTransitKeyConfiguration(String token, String keyName, VaultTransitKeyConfigBody body) {
-        return vaultClient.post("transit/keys/" + keyName + "/config", token, body, 204);
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [TRANSIT]";
     }
 
-    public Uni<Void> createTransitKey(String token, String keyName, VaultTransitCreateKeyBody body) {
-        return vaultClient.post("transit/keys/" + keyName, token, body, 204);
+    public Uni<Void> updateTransitKeyConfiguration(VaultClient vaultClient, String token, String keyName,
+            VaultTransitKeyConfigBody body) {
+        return vaultClient.post(opName("Configure Key"), "transit/keys/" + keyName + "/config", token, body, 204);
     }
 
-    public Uni<Void> deleteTransitKey(String token, String keyName) {
-        return vaultClient.delete("transit/keys/" + keyName, token, 204);
+    public Uni<Void> createTransitKey(VaultClient vaultClient, String token, String keyName, VaultTransitCreateKeyBody body) {
+        return vaultClient.post(opName("Create Key"), "transit/keys/" + keyName, token, body, 204);
     }
 
-    public Uni<VaultTransitKeyExport> exportTransitKey(String token, String keyType, String keyName, String version) {
+    public Uni<Void> deleteTransitKey(VaultClient vaultClient, String token, String keyName) {
+        return vaultClient.delete(opName("Delete Key"), "transit/keys/" + keyName, token, 204);
+    }
+
+    public Uni<VaultTransitKeyExport> exportTransitKey(VaultClient vaultClient, String token, String keyType, String keyName,
+            String version) {
         String path = "transit/export/" + keyType + "/" + keyName + (version != null ? "/" + version : "");
-        return vaultClient.get(path, token, VaultTransitKeyExport.class);
+        return vaultClient.get(opName("Export Key"), path, token, VaultTransitKeyExport.class);
     }
 
-    public Uni<VaultTransitReadKeyResult> readTransitKey(String token, String keyName) {
-        return vaultClient.get("transit/keys/" + keyName, token, VaultTransitReadKeyResult.class);
+    public Uni<VaultTransitReadKeyResult> readTransitKey(VaultClient vaultClient, String token, String keyName) {
+        return vaultClient.get(opName("Read Key"), "transit/keys/" + keyName, token, VaultTransitReadKeyResult.class);
     }
 
-    public Uni<VaultTransitListKeysResult> listTransitKeys(String token) {
-        return vaultClient.list("transit/keys", token, VaultTransitListKeysResult.class);
+    public Uni<VaultTransitListKeysResult> listTransitKeys(VaultClient vaultClient, String token) {
+        return vaultClient.list(opName("List Keys"), "transit/keys", token, VaultTransitListKeysResult.class);
     }
 
-    public Uni<VaultTransitEncrypt> encrypt(String token, String keyName, VaultTransitEncryptBody body) {
-        return vaultClient.post("transit/encrypt/" + keyName, token, body, VaultTransitEncrypt.class);
+    public Uni<VaultTransitEncrypt> encrypt(VaultClient vaultClient, String token, String keyName,
+            VaultTransitEncryptBody body) {
+        return vaultClient.post(opName("Encrypt Key"), "transit/encrypt/" + keyName, token, body, VaultTransitEncrypt.class);
     }
 
-    public Uni<VaultTransitDecrypt> decrypt(String token, String keyName, VaultTransitDecryptBody body) {
-        return vaultClient.post("transit/decrypt/" + keyName, token, body, VaultTransitDecrypt.class);
+    public Uni<VaultTransitDecrypt> decrypt(VaultClient vaultClient, String token, String keyName,
+            VaultTransitDecryptBody body) {
+        return vaultClient.post(opName("Decrypt Key"), "transit/decrypt/" + keyName, token, body, VaultTransitDecrypt.class);
     }
 
-    public Uni<VaultTransitSign> sign(String token, String keyName, String hashAlgorithm, VaultTransitSignBody body) {
+    public Uni<VaultTransitSign> sign(VaultClient vaultClient, String token, String keyName, String hashAlgorithm,
+            VaultTransitSignBody body) {
         String path = "transit/sign/" + keyName + (hashAlgorithm == null ? "" : "/" + hashAlgorithm);
-        return vaultClient.post(path, token, body, VaultTransitSign.class);
+        return vaultClient.post(opName("Sign"), path, token, body, VaultTransitSign.class);
     }
 
-    public Uni<VaultTransitVerify> verify(String token, String keyName, String hashAlgorithm, VaultTransitVerifyBody body) {
+    public Uni<VaultTransitVerify> verify(VaultClient vaultClient, String token, String keyName, String hashAlgorithm,
+            VaultTransitVerifyBody body) {
         String path = "transit/verify/" + keyName + (hashAlgorithm == null ? "" : "/" + hashAlgorithm);
-        return vaultClient.post(path, token, body, VaultTransitVerify.class);
+        return vaultClient.post(opName("Verify"), path, token, body, VaultTransitVerify.class);
     }
 
-    public Uni<VaultTransitEncrypt> rewrap(String token, String keyName, VaultTransitRewrapBody body) {
-        return vaultClient.post("transit/rewrap/" + keyName, token, body, VaultTransitEncrypt.class);
+    public Uni<VaultTransitEncrypt> rewrap(VaultClient vaultClient, String token, String keyName, VaultTransitRewrapBody body) {
+        return vaultClient.post(opName("Rewrap"), "transit/rewrap/" + keyName, token, body, VaultTransitEncrypt.class);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultConfigSource.java
@@ -16,8 +16,9 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.vault.VaultException;
-import io.quarkus.vault.VaultKVSecretEngine;
+import io.quarkus.vault.VaultKVSecretReactiveEngine;
 import io.quarkus.vault.runtime.VaultIOException;
+import io.quarkus.vault.runtime.client.Private;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 
 public class VaultConfigSource implements ConfigSource {
@@ -128,11 +129,12 @@ public class VaultConfigSource implements ConfigSource {
     }
 
     private Map<String, String> fetchSecrets(String path, String prefix) {
-        return prefixMap(getVaultKVSecretEngine().readSecret(path), prefix);
+        Map<String, String> secrets = getVaultKVSecretEngine().readSecret(path).await().indefinitely();
+        return prefixMap(secrets, prefix);
     }
 
-    private VaultKVSecretEngine getVaultKVSecretEngine() {
-        return Arc.container().instance(VaultKVSecretEngine.class).get();
+    private VaultKVSecretReactiveEngine getVaultKVSecretEngine() {
+        return Arc.container().instance(VaultKVSecretReactiveEngine.class, Private.Literal.INSTANCE).get();
     }
 
     private Map<String, String> prefixMap(Map<String, String> map, String prefix) {

--- a/test-framework/src/main/java/io/quarkus/vault/test/client/TestVaultClient.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/client/TestVaultClient.java
@@ -3,7 +3,7 @@ package io.quarkus.vault.test.client;
 import io.quarkus.arc.Arc;
 import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.runtime.VaultConfigHolder;
-import io.quarkus.vault.runtime.client.VertxVaultClient;
+import io.quarkus.vault.runtime.client.PrivateVertxVaultClient;
 import io.quarkus.vault.runtime.client.dto.transit.VaultTransitRandomBody;
 import io.quarkus.vault.test.client.dto.VaultAppRoleRoleId;
 import io.quarkus.vault.test.client.dto.VaultAppRoleSecretId;
@@ -12,7 +12,7 @@ import io.quarkus.vault.test.client.dto.VaultTransitHashBody;
 import io.quarkus.vault.test.client.dto.VaultTransitRandom;
 import io.smallrye.mutiny.Uni;
 
-public class TestVaultClient extends VertxVaultClient {
+public class TestVaultClient extends PrivateVertxVaultClient {
 
     private static VaultConfigHolder getConfigHolder() {
         return Arc.container().instance(VaultConfigHolder.class).get();
@@ -24,26 +24,25 @@ public class TestVaultClient extends VertxVaultClient {
 
     public TestVaultClient(VaultConfigHolder configHolder) {
         super(configHolder, new TlsConfig());
-        init();
     }
 
     public Uni<VaultAppRoleSecretId> generateAppRoleSecretId(String token, String roleName) {
-        return post("auth/approle/role/" + roleName + "/secret-id", token, null, VaultAppRoleSecretId.class);
+        return post("", "auth/approle/role/" + roleName + "/secret-id", token, null, VaultAppRoleSecretId.class);
     }
 
     public Uni<VaultAppRoleRoleId> getAppRoleRoleId(String token, String role) {
-        return get("auth/approle/role/" + role + "/role-id", token, VaultAppRoleRoleId.class);
+        return get("", "auth/approle/role/" + role + "/role-id", token, VaultAppRoleRoleId.class);
     }
 
     public Uni<Void> rotate(String token, String keyName) {
-        return post("transit/keys/" + keyName + "/rotate", token, null, null, 204);
+        return post("", "transit/keys/" + keyName + "/rotate", token, null, null, 204);
     }
 
     public Uni<VaultTransitRandom> generateRandom(String token, int byteCount, VaultTransitRandomBody body) {
-        return post("transit/random/" + byteCount, token, body, VaultTransitRandom.class);
+        return post("", "transit/random/" + byteCount, token, body, VaultTransitRandom.class);
     }
 
     public Uni<VaultTransitHash> hash(String token, String hashAlgorithm, VaultTransitHashBody body) {
-        return post("transit/hash/" + hashAlgorithm, token, body, VaultTransitHash.class);
+        return post("", "transit/hash/" + hashAlgorithm, token, body, VaultTransitHash.class);
     }
 }


### PR DESCRIPTION
Fixes #48 

## Overview
The extension used a single private `Vertx` instance it created itself during initialization. This meant that any services provided by other Quarkus extensions (e.g. telemetry reporting) did not get enabled for this extension.

It would be great if we could just use the shared `Vertx` instance provided by the `quarkus-vertx` extension but we can't. This extension provides a Vault configuration source (`VaultConfigSource`) that needs a `Vertx` instance before the shared instance is initialized.

This PR reorganizes the code to allow using the shared `Vertx` instance for everything except configuration related requests.

## A tale of two `VertxVaultClient`s
To be able to service configuration requests and participate in extended services the code was reorganized to support multiple `VaultClient` instances.

To do this, all the "internal" beans stopped injecting a `VaultClient` and their methods were altered to accept a `VaultClient` as the first parameter. This allows them to be easily used with any `VaultClient` without having to create qualified beans for each type of client.

Finally two `VertxVaultClient`s were created, `SharedVertxVaultClient` and `PrivateVertxVaultClient`.

### PrivateVertxVaultClient
`PrivateVertxVaultClient` uses a private `Vertx` instance, just as `VertxVaultClient` did previously. The only difference between the previous `VertxVaultClient` and `PrivateVertxVaultClient` is that the `Vertx` instance and `WebClient` are **very** lazily created. This was done to ease the complicated initialization it previously had and to ensure that if you don't use this client it will never consume extra resources.

This client is only used by `VaultConfigSource`. This ensures it will always be available even when no shared `Vertx` instance is ready or available. Due to the lazy initialization, if you don't use the config source no extra resources will be consumed. It does mean that config source related calls will not participate in extra services telemetry reporting.

### SharedVertxVaultClient
`SharedVertxVaultClient` is fairly simple and just uses the shared `Vertx` instance ensuring it participates in extended services.

This client is used everywhere (***except*** `VaultConfigSource`) making it fully integrated with all the Quarkus extensions.


## Telemetry Reporting
It should be obvious telemetry reporting was the main reason for this restructuring. To that end another change was made to better support telemetry which is that operation names have been added to all the calls.

The Vertx `WebClient` & `HttpClient` support overriding the telemetry trace title using the option `RequestOptions.traceOperation`. As part of this PR all of the "internal" classes now provide relatively short descriptive operation names (for telemetry trace titles) for each logical method.
