### PR TITLE
Handle warning only responses and log warnings

### DIFF
--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/AbstractVaultDTO.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/AbstractVaultDTO.java
@@ -1,5 +1,7 @@
 package io.quarkus.vault.runtime.client.dto;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AbstractVaultDTO<DATA, AUTH> implements VaultModel {
@@ -14,7 +16,7 @@ public class AbstractVaultDTO<DATA, AUTH> implements VaultModel {
     public DATA data;
     @JsonProperty("wrap_info")
     public WrapInfo wrapInfo;
-    public Object warnings;
+    public List<String> warnings;
     public AUTH auth;
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientException.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientException.java
@@ -4,12 +4,24 @@ import io.quarkus.vault.VaultException;
 
 public class VaultClientException extends VaultException {
 
+    private String operationName;
+    private String requestPath;
     private int status;
     private String body;
 
-    public VaultClientException(int status, String body) {
+    public VaultClientException(String operationName, String requestPath, int status, String body) {
+        this.operationName = operationName;
+        this.requestPath = requestPath;
         this.status = status;
         this.body = body;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public String getRequestPath() {
+        return requestPath;
     }
 
     public int getStatus() {
@@ -22,6 +34,11 @@ public class VaultClientException extends VaultException {
 
     @Override
     public String toString() {
-        return super.toString() + " code=" + status + " body=" + body;
+        return "VaultClientException{" +
+                "operationName='" + operationName + '\'' +
+                ", requestPath='" + requestPath + '\'' +
+                ", status=" + status +
+                ", body='" + body + '\'' +
+                '}';
     }
 }


### PR DESCRIPTION
### Warning only responses
When a request expecting a 204 returns warnings it does so by returning a standaard 200 response with the warnings attached. Previously this would result in an exception becaues of the mismatched response status code.

### Logging warnings
Any Vault response can attach warnings. Those warnings are now logged for all responses.