### PR TITLE
doc: add create capability to the policy

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -163,7 +163,7 @@ Create a policy that gives read access to `secret/myapps/vault-quickstart` and s
 ----
 cat <<EOF | vault policy write vault-quickstart-policy -
 path "secret/data/myapps/vault-quickstart/*" {
-  capabilities = ["read"]
+  capabilities = ["read", "create"]
 }
 EOF
 ----

--- a/docs/modules/ROOT/pages/vault-datasource.adoc
+++ b/docs/modules/ROOT/pages/vault-datasource.adoc
@@ -262,7 +262,7 @@ Then we need to give a read capability to the Quarkus application on path `datab
 ----
 cat <<EOF | vault policy write vault-quickstart-policy -
 path "secret/data/myapps/vault-quickstart/*" {
-  capabilities = ["read"]
+  capabilities = ["read", "create"]
 }
 path "database/creds/mydbrole" {
   capabilities = [ "read" ]


### PR DESCRIPTION
The `create` capability is needed for adding a new key step asked in the [`Programmatic access to the KV secret engine section`](https://quarkiverse.github.io/quarkiverse-docs/quarkus-vault/dev/index.html#_programmatic_access_to_the_kv_secret_engine)