### PR TITLE
Add AWS IAM Authentication

### DIFF
--- a/deployment/src/main/java/io/quarkus/vault/deployment/VaultProcessor.java
+++ b/deployment/src/main/java/io/quarkus/vault/deployment/VaultProcessor.java
@@ -40,6 +40,7 @@ import io.quarkus.vault.runtime.VaultTransitManager;
 import io.quarkus.vault.runtime.client.PrivateVertxVaultClient;
 import io.quarkus.vault.runtime.client.SharedVertxVaultClient;
 import io.quarkus.vault.runtime.client.authmethod.VaultInternalAppRoleAuthMethod;
+import io.quarkus.vault.runtime.client.authmethod.VaultInternalAwsIamAuthMethod;
 import io.quarkus.vault.runtime.client.authmethod.VaultInternalKubernetesAuthMethod;
 import io.quarkus.vault.runtime.client.authmethod.VaultInternalTokenAuthMethod;
 import io.quarkus.vault.runtime.client.authmethod.VaultInternalUserpassAuthMethod;
@@ -119,6 +120,7 @@ public class VaultProcessor {
                 .addBeanClass(VaultInternalUserpassAuthMethod.class)
                 .addBeanClass(VaultInternalDynamicCredentialsSecretEngine.class)
                 .addBeanClass(VaultInternalPKISecretEngine.class)
+                .addBeanClass(VaultInternalAwsIamAuthMethod.class)
                 .build();
     }
 

--- a/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
@@ -867,6 +867,102 @@ endif::add-copy-button-to-env-var[]
 |`auth/kubernetes`
 
 
+a| [[quarkus-vault_quarkus.vault.authentication.aws-iam.role]]`link:#quarkus-vault_quarkus.vault.authentication.aws-iam.role[quarkus.vault.authentication.aws-iam.role]`
+
+[.description]
+--
+AWS IAM authentication role that has been created in Vault to associate Vault policies, with ARN. This property is required when selecting the AWS IAM authentication type.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_ROLE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_ROLE+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-vault_quarkus.vault.authentication.aws-iam.region]]`link:#quarkus-vault_quarkus.vault.authentication.aws-iam.region[quarkus.vault.authentication.aws-iam.region]`
+
+[.description]
+--
+The AWS region to use for AWS IAM authentication.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_REGION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_REGION+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-vault_quarkus.vault.authentication.aws-iam.sts-url]]`link:#quarkus-vault_quarkus.vault.authentication.aws-iam.sts-url[quarkus.vault.authentication.aws-iam.sts-url]`
+
+[.description]
+--
+The URL of the AWS STS endpoint to use for AWS IAM authentication.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_STS_URL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_STS_URL+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`https://sts.amazonaws.com`
+
+
+a| [[quarkus-vault_quarkus.vault.authentication.aws-iam.vault-server-id]]`link:#quarkus-vault_quarkus.vault.authentication.aws-iam.vault-server-id[quarkus.vault.authentication.aws-iam.vault-server-id]`
+
+[.description]
+--
+The Vault server ID to use for AWS IAM authentication.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_VAULT_SERVER_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_VAULT_SERVER_ID+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-vault_quarkus.vault.authentication.aws-iam.aws-access-key]]`link:#quarkus-vault_quarkus.vault.authentication.aws-iam.aws-access-key[quarkus.vault.authentication.aws-iam.aws-access-key]`
+
+[.description]
+--
+The AWS access key ID to use for AWS IAM authentication.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_AWS_ACCESS_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_AWS_ACCESS_KEY+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
+a| [[quarkus-vault_quarkus.vault.authentication.aws-iam.aws-secret-key]]`link:#quarkus-vault_quarkus.vault.authentication.aws-iam.aws-secret-key[quarkus.vault.authentication.aws-iam.aws-secret-key]`
+
+[.description]
+--
+The AWS secret access key to use for AWS IAM authentication.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_AWS_SECRET_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_VAULT_AUTHENTICATION_AWS_IAM_AWS_SECRET_KEY+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|
+
+
 h|[[quarkus-vault_quarkus.vault.tls-tls]]link:#quarkus-vault_quarkus.vault.tls-tls[TLS]
 
 h|Type

--- a/integration-tests/vault-agroal/pom.xml
+++ b/integration-tests/vault-agroal/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>quarkus-jdbc-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/vault-app/pom.xml
+++ b/integration-tests/vault-app/pom.xml
@@ -32,6 +32,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/integration-tests/vault-app/pom.xml
+++ b/integration-tests/vault-app/pom.xml
@@ -32,10 +32,22 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
+
+        <!--
+            Temporary workaround for native tests to work.
+            Since aws auth is not used by application, the dependency on awssdk should be omitted.
+            And normal tests work fine if this dependency is only in test scope (required by vault test resource).
+            However, native tests fail if this dependency is not in compile scope.
+        -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
-            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- test dependencies -->

--- a/integration-tests/vault/pom.xml
+++ b/integration-tests/vault/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.vault</groupId>
             <artifactId>quarkus-vault-deployment</artifactId>
             <version>${project.version}</version>

--- a/integration-tests/vault/pom.xml
+++ b/integration-tests/vault/pom.xml
@@ -36,6 +36,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.vault</groupId>

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAwsIamITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAwsIamITCase.java
@@ -3,7 +3,10 @@ package io.quarkus.vault;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import jakarta.inject.Inject;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -11,6 +14,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.runtime.client.VaultClient;
+import io.quarkus.vault.runtime.client.authmethod.VaultInternalAwsIamAuthMethod;
+import io.quarkus.vault.runtime.client.dto.auth.VaultAwsIamAuth;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
 @DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
@@ -22,20 +28,37 @@ public class VaultAwsIamITCase {
             .withApplicationRoot((jar) -> jar
                     .addAsResource("application-vault-aws-iam.properties", "application.properties"));
 
+    private static final Logger log = Logger.getLogger(VaultAwsIamITCase.class);
+
     @ConfigProperty(name = "quarkus.vault.authentication.aws-iam.role")
     String role;
 
     @ConfigProperty(name = "quarkus.vault.authentication.aws-iam.aws-access-key")
     String key;
 
+    @Inject
+    VaultClient vaultClient;
+
+    @Inject
+    VaultInternalAwsIamAuthMethod vaultInternalAwsIamAuthMethod;
+
     @Test
-    public void testRole() {
+    public void testRoleConfig() {
         assertEquals("myawsiamrole", role);
     }
 
     @Test
-    public void testAwsAccessKey() {
+    public void testAwsAccessKeyConfig() {
         assertNotNull(key);
+    }
+
+    @Test
+    public void testSuccessAuth() {
+        final VaultAwsIamAuth auth = vaultInternalAwsIamAuthMethod.login(vaultClient).await().indefinitely();
+
+        String awsIamClientToken = auth.auth.clientToken;
+        log.info("awsIamClientToken = " + awsIamClientToken);
+        assertNotNull(awsIamClientToken);
     }
 
 }

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAwsIamITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAwsIamITCase.java
@@ -5,12 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.vault.test.VaultTestLifecycleManager;
 
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
 @QuarkusTestResource(VaultTestLifecycleManager.class)
 public class VaultAwsIamITCase {
 
@@ -31,8 +34,7 @@ public class VaultAwsIamITCase {
     }
 
     @Test
-    public void testAuthMountPath() {
-        System.out.println("key: " + key);
+    public void testAwsAccessKey() {
         assertNotNull(key);
     }
 

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAwsIamITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAwsIamITCase.java
@@ -1,0 +1,39 @@
+package io.quarkus.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultAwsIamITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-vault-aws-iam.properties", "application.properties"));
+
+    @ConfigProperty(name = "quarkus.vault.authentication.aws-iam.role")
+    String role;
+
+    @ConfigProperty(name = "quarkus.vault.authentication.aws-iam.aws-access-key")
+    String key;
+
+    @Test
+    public void testRole() {
+        assertEquals("myawsiamrole", role);
+    }
+
+    @Test
+    public void testAuthMountPath() {
+        System.out.println("key: " + key);
+        assertNotNull(key);
+    }
+
+}

--- a/integration-tests/vault/src/test/resources/application-vault-aws-iam.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-aws-iam.properties
@@ -1,0 +1,20 @@
+quarkus.vault.url=https://localhost:8200
+
+# vault-test.client-token-wrapping-token provided by VaultTestLifecycleManager
+quarkus.vault.authentication.aws-iam.role=myawsiamrole
+quarkus.vault.authentication.aws-iam.region=us-east-1
+quarkus.vault.authentication.aws-iam.sts-url=http://mylocalstack:4566
+quarkus.vault.authentication.aws-iam.vault-server-id=vault.example.com
+quarkus.vault.authentication.aws-iam.aws-access-key=${vault-test.aws-user.access-key}
+quarkus.vault.authentication.aws-iam.aws-secret-key=${vault-test.aws-user.secret-key}
+
+#quarkus.vault.tls.skip-verify=true
+quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
+
+#quarkus.vault.log-confidentiality-level=low
+#quarkus.vault.renew-grace-period=10
+
+quarkus.log.category."io.quarkus.vault".level=DEBUG
+
+#quarkus.log.level=DEBUG
+#quarkus.log.console.level=DEBUG

--- a/integration-tests/vault/src/test/resources/application-vault-aws-iam.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-aws-iam.properties
@@ -8,13 +8,9 @@ quarkus.vault.authentication.aws-iam.vault-server-id=vault.example.com
 quarkus.vault.authentication.aws-iam.aws-access-key=${vault-test.aws-user.access-key}
 quarkus.vault.authentication.aws-iam.aws-secret-key=${vault-test.aws-user.secret-key}
 
-#quarkus.vault.tls.skip-verify=true
 quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
 
-#quarkus.vault.log-confidentiality-level=low
-#quarkus.vault.renew-grace-period=10
+quarkus.vault.log-confidentiality-level=low
+quarkus.vault.renew-grace-period=10
 
 quarkus.log.category."io.quarkus.vault".level=DEBUG
-
-#quarkus.log.level=DEBUG
-#quarkus.log.console.level=DEBUG

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuth.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuth.java
@@ -1,0 +1,45 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import io.quarkus.vault.runtime.client.dto.AbstractVaultDTO;
+
+/*
+
+{
+  "request_id": "9e923c23-3a45-ff0f-a3ea-5fffd94f1e2f",
+  "lease_id": "",
+  "renewable": false,
+  "lease_duration": 0,
+  "data": null,
+  "wrap_info": null,
+  "warnings": null,
+  "auth": {
+    "client_token": "s.aWvAbfqWpoqPpbTebdwDEVuu",
+    "accessor": "abbJ8vD3JghuH37Up5d0SLYM",
+    "policies": [
+      "default",
+      "mypolicy"
+    ],
+    "token_policies": [
+      "default",
+      "mypolicy"
+    ],
+    "metadata": {
+      "role": "myapprole",
+      "service_account_name": "default",
+      "service_account_namespace": "vaultapp",
+      "service_account_secret_name": "default-token-qj4b5",
+      "service_account_uid": "27c26105-92d3-11e9-9202-025000000001"
+    },
+    "lease_duration": 7200,
+    "renewable": true,
+    "entity_id": "62f850bb-4835-a9ea-471b-006a92017128",
+    "token_type": "service",
+    "orphan": true
+  }
+}
+
+
+*/
+public class VaultAwsIamAuth extends AbstractVaultDTO<Object, VaultAwsIamAuthAuth> {
+
+}

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthAuth.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthAuth.java
@@ -1,0 +1,4 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+public class VaultAwsIamAuthAuth extends AbstractVaultAuthAuth<VaultAwsIamAuthAuthMetadata> {
+}

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthAuthMetadata.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthAuthMetadata.java
@@ -4,5 +4,4 @@ import io.quarkus.vault.runtime.client.dto.VaultModel;
 
 public class VaultAwsIamAuthAuthMetadata implements VaultModel {
 
-
 }

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthAuthMetadata.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthAuthMetadata.java
@@ -1,0 +1,8 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultAwsIamAuthAuthMetadata implements VaultModel {
+
+
+}

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthBody.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthBody.java
@@ -22,11 +22,11 @@ public class VaultAwsIamAuthBody implements VaultModel {
     public Base64String requestHeaders;
 
     public VaultAwsIamAuthBody(
-      final String role,
-      final String requestMethod,
-      final Base64String requestUrl,
-      final Base64String requestBody,
-      final Base64String requestHeaders
+            final String role,
+            final String requestMethod,
+            final Base64String requestUrl,
+            final Base64String requestBody,
+            final Base64String requestHeaders
     ) {
         this.role = role;
         this.requestMethod = requestMethod;

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthBody.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthBody.java
@@ -26,8 +26,7 @@ public class VaultAwsIamAuthBody implements VaultModel {
             final String requestMethod,
             final Base64String requestUrl,
             final Base64String requestBody,
-            final Base64String requestHeaders
-    ) {
+            final Base64String requestHeaders) {
         this.role = role;
         this.requestMethod = requestMethod;
         this.requestUrl = requestUrl;

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthBody.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/auth/VaultAwsIamAuthBody.java
@@ -1,0 +1,37 @@
+package io.quarkus.vault.runtime.client.dto.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.quarkus.vault.runtime.Base64String;
+import io.quarkus.vault.runtime.client.dto.VaultModel;
+
+public class VaultAwsIamAuthBody implements VaultModel {
+
+    public String role;
+
+    @JsonProperty("iam_http_request_method")
+    public String requestMethod;
+
+    @JsonProperty("iam_request_url")
+    public Base64String requestUrl;
+
+    @JsonProperty("iam_request_body")
+    public Base64String requestBody;
+
+    @JsonProperty("iam_request_headers")
+    public Base64String requestHeaders;
+
+    public VaultAwsIamAuthBody(
+      final String role,
+      final String requestMethod,
+      final Base64String requestUrl,
+      final Base64String requestBody,
+      final Base64String requestHeaders
+    ) {
+        this.role = role;
+        this.requestMethod = requestMethod;
+        this.requestUrl = requestUrl;
+        this.requestBody = requestBody;
+        this.requestHeaders = requestHeaders;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.20.94</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj.version}</version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -9,17 +9,6 @@
     <artifactId>quarkus-vault</artifactId>
     <name>Quarkus - Vault - Runtime</name>
     <description>Store your credentials securely in HashiCorp Vault</description>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>bom</artifactId>
-                <version>2.20.94</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -9,6 +9,17 @@
     <artifactId>quarkus-vault</artifactId>
     <name>Quarkus - Vault - Runtime</name>
     <description>Store your credentials securely in HashiCorp Vault</description>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.20.94</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -47,6 +58,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultAuthManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultAuthManager.java
@@ -1,20 +1,7 @@
 package io.quarkus.vault.runtime;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import io.quarkus.vault.VaultException;
-import io.quarkus.vault.runtime.client.VaultClient;
-import io.quarkus.vault.runtime.client.VaultClientException;
-import io.quarkus.vault.runtime.client.authmethod.*;
-import io.quarkus.vault.runtime.client.backend.VaultInternalSystemBackend;
-import io.quarkus.vault.runtime.client.dto.auth.*;
-import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV1;
-import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2;
-import io.quarkus.vault.runtime.config.VaultAuthenticationType;
-import io.quarkus.vault.runtime.config.VaultBootstrapConfig;
-import io.smallrye.mutiny.Uni;
-import jakarta.inject.Singleton;
-import org.jboss.logging.Logger;
+import static io.quarkus.vault.runtime.LogConfidentialityLevel.LOW;
+import static io.quarkus.vault.runtime.config.VaultAuthenticationType.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -25,8 +12,24 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import static io.quarkus.vault.runtime.LogConfidentialityLevel.LOW;
-import static io.quarkus.vault.runtime.config.VaultAuthenticationType.*;
+import io.quarkus.vault.runtime.client.authmethod.*;
+import io.quarkus.vault.runtime.client.dto.auth.*;
+import jakarta.inject.Singleton;
+
+import org.jboss.logging.Logger;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.quarkus.vault.VaultException;
+import io.quarkus.vault.runtime.client.VaultClient;
+import io.quarkus.vault.runtime.client.VaultClientException;
+import io.quarkus.vault.runtime.client.backend.VaultInternalSystemBackend;
+import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV1;
+import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2;
+import io.quarkus.vault.runtime.config.VaultAuthenticationType;
+import io.quarkus.vault.runtime.config.VaultBootstrapConfig;
+import io.smallrye.mutiny.Uni;
 
 /**
  * Handles authentication. Supports revocation and renewal.

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultAuthManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultAuthManager.java
@@ -12,8 +12,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import io.quarkus.vault.runtime.client.authmethod.*;
-import io.quarkus.vault.runtime.client.dto.auth.*;
 import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
@@ -24,7 +22,9 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import io.quarkus.vault.VaultException;
 import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultClientException;
+import io.quarkus.vault.runtime.client.authmethod.*;
 import io.quarkus.vault.runtime.client.backend.VaultInternalSystemBackend;
+import io.quarkus.vault.runtime.client.dto.auth.*;
 import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV1;
 import io.quarkus.vault.runtime.client.dto.kv.VaultKvSecretV2;
 import io.quarkus.vault.runtime.config.VaultAuthenticationType;
@@ -166,9 +166,9 @@ public class VaultAuthManager {
         } else if (type == APPROLE) {
             String roleId = getConfig().authentication.appRole.roleId.get();
             authRequest = getSecretId(vaultClient)
-              .flatMap(secretId -> vaultInternalAppRoleAuthMethod.login(vaultClient, roleId, secretId))
-              .map(r -> r.auth);
-        } else if (type == AWS_IAM){
+                    .flatMap(secretId -> vaultInternalAppRoleAuthMethod.login(vaultClient, roleId, secretId))
+                    .map(r -> r.auth);
+        } else if (type == AWS_IAM) {
             authRequest = loginAwsIam(vaultClient);
         } else {
             throw new UnsupportedOperationException("unknown authType " + getConfig().getAuthenticationType());

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAwsIamAuthMethod.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAwsIamAuthMethod.java
@@ -12,9 +12,11 @@ import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.auth.VaultAwsIamAuth;
 import io.quarkus.vault.runtime.client.dto.auth.VaultAwsIamAuthBody;
+import io.quarkus.vault.runtime.config.VaultAwsIamAuthenticationConfig;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
@@ -97,8 +99,14 @@ public class VaultInternalAwsIamAuthMethod extends VaultInternalBase {
   }
 
   private AwsCredentials getAwsCredentials() {
-    try (DefaultCredentialsProvider defaultCredentialsProvider = DefaultCredentialsProvider.create()) {
-      return defaultCredentialsProvider.resolveCredentials();
+    final VaultAwsIamAuthenticationConfig awsIam = vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam;
+
+    if (awsIam.awsAccessKey.isPresent() && awsIam.awsSecretKey.isPresent()) {
+      return AwsBasicCredentials.create(awsIam.awsAccessKey.get(), awsIam.awsSecretKey.get());
+    } else {
+      try (DefaultCredentialsProvider defaultCredentialsProvider = DefaultCredentialsProvider.create()) {
+        return defaultCredentialsProvider.resolveCredentials();
+      }
     }
   }
 

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAwsIamAuthMethod.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAwsIamAuthMethod.java
@@ -1,10 +1,5 @@
 package io.quarkus.vault.runtime.client.authmethod;
 
-import java.io.ByteArrayInputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.stream.Collectors;
-
 import io.quarkus.vault.runtime.Base64String;
 import io.quarkus.vault.runtime.StringHelper;
 import io.quarkus.vault.runtime.VaultConfigHolder;
@@ -25,107 +20,103 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.regions.Region;
 
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.joining;
+
 @Singleton
 public class VaultInternalAwsIamAuthMethod extends VaultInternalBase {
 
-  private static final String GET_CALLER_IDENTITY_REQUEST_BODY = "Action=GetCallerIdentity&Version=2011-06-15";
-  @Inject
-  private VaultConfigHolder vaultConfigHolder;
+    private static final String GET_CALLER_IDENTITY_REQUEST_BODY = "Action=GetCallerIdentity&Version=2011-06-15";
+    @Inject
+    private VaultConfigHolder vaultConfigHolder;
 
-  @Override
-  protected String opNamePrefix() {
-    return super.opNamePrefix() + " [AUTH (aws iam)]";
-  }
-
-  /**
-   * curl -X POST "http://127.0.0.1:8200/v1/auth/aws/login" -d '{
-   *   "role":"dev",
-   *   "iam_http_request_method": "POST",
-   *   "iam_request_url": "aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8=",
-   *   "iam_request_body": "QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNQ==",
-   *   "iam_request_headers": "eyJDb250ZW50LUxlbmd0aCI6IFsiNDMiXSwgIlVzZXItQWdlbnQiOiBbImF3cy1zZGstZ28vMS40LjEyIChnbzEuNy4xOyBsaW51eDsgYW1kNjQpIl0sICJYLVZhdWx0LUFXU0lBTS1TZXJ2ZXItSWQiOiBbInZhdWx0LmV4YW1wbGUuY29tIl0sICJYLUFtei1EYXRlIjogWyIyMDE2MDkzMFQwNDMxMjFaIl0sICJDb250ZW50LVR5cGUiOiBbImFwcGxpY2F0aW9uL3gtd3d3LWZvcm0tdXJsZW5jb2RlZDsgY2hhcnNldD11dGYtOCJdLCAiQXV0aG9yaXphdGlvbiI6IFsiQVdTNC1ITUFDLVNIQTI1NiBDcmVkZW50aWFsPWZvby8yMDE2MDkzMC91cy1lYXN0LTEvc3RzL2F3czRfcmVxdWVzdCwgU2lnbmVkSGVhZGVycz1jb250ZW50LWxlbmd0aDtjb250ZW50LXR5cGU7aG9zdDt4LWFtei1kYXRlO3gtdmF1bHQtc2VydmVyLCBTaWduYXR1cmU9YTY5ZmQ3NTBhMzQ0NWM0ZTU1M2UxYjNlNzlkM2RhOTBlZWY1NDA0N2YxZWI0ZWZlOGZmYmM5YzQyOGMyNjU1YiJdfQ==" }'
-   *
-   *
-   *   Config PARAMS:
-   *   - region
-   *   - sts url
-   *   - X-Vault-AWS-IAM-Server-ID
-   */
-  public Uni<VaultAwsIamAuth> login(final VaultClient vaultClient) {
-    final SdkHttpFullRequest getCallerIdentityRequest;
-    try {
-      getCallerIdentityRequest = buildGetCallerIdentityRequest();
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
+    @Override
+    protected String opNamePrefix() {
+        return super.opNamePrefix() + " [AUTH (aws iam)]";
     }
-    final AwsCredentials creds = getAwsCredentials();
-    final SdkHttpFullRequest signedRequest = signRequest(getCallerIdentityRequest, creds);
 
-    final VaultAwsIamAuthBody vaultRequestBody = buildVaultRequestBody(signedRequest);
+    public Uni<VaultAwsIamAuth> login(VaultClient vaultClient) {
+        SdkHttpFullRequest getCallerIdentityRequest;
+        try {
+            getCallerIdentityRequest = buildGetCallerIdentityRequest();
+        } catch (URISyntaxException ex) {
+            throw new IllegalArgumentException("STS URI is not correct", ex);
+        }
+        AwsCredentials awsCredentials = getAwsCredentials();
+        SdkHttpFullRequest signedRequest = signRequest(getCallerIdentityRequest, awsCredentials);
 
-    return vaultClient.post(opName("Login"), "auth/aws/login", null, vaultRequestBody,
-      VaultAwsIamAuth.class);
-  }
+        VaultAwsIamAuthBody vaultRequestBody = buildVaultRequestBody(signedRequest);
 
-  private VaultAwsIamAuthBody buildVaultRequestBody(final SdkHttpFullRequest signedRequest) {
-    final String headersString = "{"
-      + signedRequest.headers().entrySet().stream()
-      .map(entry -> "\"" + entry.getKey() + "\":["
-        + entry.getValue().stream().map(value -> "\"" + value + "\"").collect(Collectors.joining(","))
-        + "]")
-      .collect(Collectors.joining(","))
-      + "}";
+        return vaultClient.post(opName("Login"), "auth/aws/login", null, vaultRequestBody,
+                VaultAwsIamAuth.class);
+    }
 
-    return new VaultAwsIamAuthBody(
-      vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.role,
-      "POST",
-      Base64String.from(signedRequest.getUri().toString()),
-      Base64String.from(GET_CALLER_IDENTITY_REQUEST_BODY),
-      Base64String.from(headersString)
-    );
+    private VaultAwsIamAuthBody buildVaultRequestBody(SdkHttpFullRequest signedRequest) {
+      String headersString = headersToJsonString(signedRequest.headers());
+
+      return new VaultAwsIamAuthBody(
+                vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.role,
+                "POST",
+                Base64String.from(signedRequest.getUri().toString()),
+                Base64String.from(GET_CALLER_IDENTITY_REQUEST_BODY),
+                Base64String.from(headersString)
+        );
+    }
+
+  private static String headersToJsonString(Map<String, List<String>> headers) {
+    return "{"
+            + headers.entrySet().stream()
+            .map(entry -> "\"" + entry.getKey() + "\":["
+                    + entry.getValue().stream().map(value -> "\"" + value + "\"").collect(joining(","))
+                    + "]")
+            .collect(joining(","))
+            + "}";
   }
 
   private SdkHttpFullRequest signRequest(
-    final SdkHttpFullRequest getCallerIdentityRequest,
-    final AwsCredentials creds
-  ) {
-    final Region region = Region.of(vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.region);
-    Aws4SignerParams params = Aws4SignerParams.builder()
-      .awsCredentials(creds)
-      .signingName("sts")
-      .signingRegion(region)
-      .build();
-    return Aws4Signer.create().sign(getCallerIdentityRequest, params);
-  }
-
-  private AwsCredentials getAwsCredentials() {
-    final VaultAwsIamAuthenticationConfig awsIam = vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam;
-
-    if (awsIam.awsAccessKey.isPresent() && awsIam.awsSecretKey.isPresent()) {
-      return AwsBasicCredentials.create(awsIam.awsAccessKey.get(), awsIam.awsSecretKey.get());
-    } else {
-      try (DefaultCredentialsProvider defaultCredentialsProvider = DefaultCredentialsProvider.create()) {
-        return defaultCredentialsProvider.resolveCredentials();
-      }
+            SdkHttpFullRequest getCallerIdentityRequest,
+            AwsCredentials awsCredentials
+    ) {
+        Region region = Region.of(vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.region);
+        Aws4SignerParams params = Aws4SignerParams.builder()
+                .awsCredentials(awsCredentials)
+                .signingName("sts")
+                .signingRegion(region)
+                .build();
+        return Aws4Signer.create().sign(getCallerIdentityRequest, params);
     }
-  }
 
-  private SdkHttpFullRequest buildGetCallerIdentityRequest() throws URISyntaxException {
-    final SdkHttpFullRequest.Builder builder = SdkHttpFullRequest.builder()
-      .method(SdkHttpMethod.POST)
-      .uri(new URI(vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.stsUrl))
-      .appendHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
-      .appendHeader("Content-Length", String.valueOf(GET_CALLER_IDENTITY_REQUEST_BODY.length()))
-      .contentStreamProvider(() -> new ByteArrayInputStream(
-        StringHelper.stringToBytes(GET_CALLER_IDENTITY_REQUEST_BODY)
-      ));
+    private AwsCredentials getAwsCredentials() {
+        VaultAwsIamAuthenticationConfig awsIam = vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam;
 
-    vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.vaultServerId.ifPresent(
-      serverId -> builder.appendHeader("X-Vault-AWS-IAM-Server-ID", serverId)
-    );
+        if (awsIam.awsAccessKey.isPresent() && awsIam.awsSecretKey.isPresent()) {
+            return AwsBasicCredentials.create(awsIam.awsAccessKey.get(), awsIam.awsSecretKey.get());
+        } else {
+            try (DefaultCredentialsProvider defaultCredentialsProvider = DefaultCredentialsProvider.create()) {
+                return defaultCredentialsProvider.resolveCredentials();
+            }
+        }
+    }
 
-    SdkHttpFullRequest request = builder.build();
-    // log request
-    return request;
-  }
+    private SdkHttpFullRequest buildGetCallerIdentityRequest() throws URISyntaxException {
+        SdkHttpFullRequest.Builder builder = SdkHttpFullRequest.builder()
+                .method(SdkHttpMethod.POST)
+                .uri(new URI(vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.stsUrl))
+                .appendHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+                .appendHeader("Content-Length", String.valueOf(GET_CALLER_IDENTITY_REQUEST_BODY.length()))
+                .contentStreamProvider(() -> new ByteArrayInputStream(
+                        StringHelper.stringToBytes(GET_CALLER_IDENTITY_REQUEST_BODY)
+                ));
+
+        vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.vaultServerId.ifPresent(
+                serverId -> builder.appendHeader("X-Vault-AWS-IAM-Server-ID", serverId)
+        );
+
+        return builder.build();
+    }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAwsIamAuthMethod.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAwsIamAuthMethod.java
@@ -1,0 +1,25 @@
+package io.quarkus.vault.runtime.client.authmethod;
+
+import io.quarkus.vault.runtime.VaultConfigHolder;
+import io.quarkus.vault.runtime.client.VaultClient;
+import io.quarkus.vault.runtime.client.VaultInternalBase;
+import io.quarkus.vault.runtime.client.dto.auth.VaultAwsIamAuth;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class VaultInternalAwsIamAuthMethod extends VaultInternalBase {
+
+  @Inject
+  private VaultConfigHolder vaultConfigHolder;
+
+  @Override
+  protected String opNamePrefix() {
+    return super.opNamePrefix() + " [AUTH (aws iam)]";
+  }
+
+  public Uni<VaultAwsIamAuth> login(final VaultClient vaultClient) {
+    return null;
+  }
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAwsIamAuthMethod.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/authmethod/VaultInternalAwsIamAuthMethod.java
@@ -1,16 +1,32 @@
 package io.quarkus.vault.runtime.client.authmethod;
 
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.stream.Collectors;
+
+import io.quarkus.vault.runtime.Base64String;
+import io.quarkus.vault.runtime.StringHelper;
 import io.quarkus.vault.runtime.VaultConfigHolder;
 import io.quarkus.vault.runtime.client.VaultClient;
 import io.quarkus.vault.runtime.client.VaultInternalBase;
 import io.quarkus.vault.runtime.client.dto.auth.VaultAwsIamAuth;
+import io.quarkus.vault.runtime.client.dto.auth.VaultAwsIamAuthBody;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
 
 @Singleton
 public class VaultInternalAwsIamAuthMethod extends VaultInternalBase {
 
+  private static final String GET_CALLER_IDENTITY_REQUEST_BODY = "Action=GetCallerIdentity&Version=2011-06-15";
   @Inject
   private VaultConfigHolder vaultConfigHolder;
 
@@ -19,7 +35,89 @@ public class VaultInternalAwsIamAuthMethod extends VaultInternalBase {
     return super.opNamePrefix() + " [AUTH (aws iam)]";
   }
 
+  /**
+   * curl -X POST "http://127.0.0.1:8200/v1/auth/aws/login" -d '{
+   *   "role":"dev",
+   *   "iam_http_request_method": "POST",
+   *   "iam_request_url": "aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8=",
+   *   "iam_request_body": "QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNQ==",
+   *   "iam_request_headers": "eyJDb250ZW50LUxlbmd0aCI6IFsiNDMiXSwgIlVzZXItQWdlbnQiOiBbImF3cy1zZGstZ28vMS40LjEyIChnbzEuNy4xOyBsaW51eDsgYW1kNjQpIl0sICJYLVZhdWx0LUFXU0lBTS1TZXJ2ZXItSWQiOiBbInZhdWx0LmV4YW1wbGUuY29tIl0sICJYLUFtei1EYXRlIjogWyIyMDE2MDkzMFQwNDMxMjFaIl0sICJDb250ZW50LVR5cGUiOiBbImFwcGxpY2F0aW9uL3gtd3d3LWZvcm0tdXJsZW5jb2RlZDsgY2hhcnNldD11dGYtOCJdLCAiQXV0aG9yaXphdGlvbiI6IFsiQVdTNC1ITUFDLVNIQTI1NiBDcmVkZW50aWFsPWZvby8yMDE2MDkzMC91cy1lYXN0LTEvc3RzL2F3czRfcmVxdWVzdCwgU2lnbmVkSGVhZGVycz1jb250ZW50LWxlbmd0aDtjb250ZW50LXR5cGU7aG9zdDt4LWFtei1kYXRlO3gtdmF1bHQtc2VydmVyLCBTaWduYXR1cmU9YTY5ZmQ3NTBhMzQ0NWM0ZTU1M2UxYjNlNzlkM2RhOTBlZWY1NDA0N2YxZWI0ZWZlOGZmYmM5YzQyOGMyNjU1YiJdfQ==" }'
+   *
+   *
+   *   Config PARAMS:
+   *   - region
+   *   - sts url
+   *   - X-Vault-AWS-IAM-Server-ID
+   */
   public Uni<VaultAwsIamAuth> login(final VaultClient vaultClient) {
-    return null;
+    final SdkHttpFullRequest getCallerIdentityRequest;
+    try {
+      getCallerIdentityRequest = buildGetCallerIdentityRequest();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    final AwsCredentials creds = getAwsCredentials();
+    final SdkHttpFullRequest signedRequest = signRequest(getCallerIdentityRequest, creds);
+
+    final VaultAwsIamAuthBody vaultRequestBody = buildVaultRequestBody(signedRequest);
+
+    return vaultClient.post(opName("Login"), "auth/aws/login", null, vaultRequestBody,
+      VaultAwsIamAuth.class);
+  }
+
+  private VaultAwsIamAuthBody buildVaultRequestBody(final SdkHttpFullRequest signedRequest) {
+    final String headersString = "{"
+      + signedRequest.headers().entrySet().stream()
+      .map(entry -> "\"" + entry.getKey() + "\":["
+        + entry.getValue().stream().map(value -> "\"" + value + "\"").collect(Collectors.joining(","))
+        + "]")
+      .collect(Collectors.joining(","))
+      + "}";
+
+    return new VaultAwsIamAuthBody(
+      vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.role,
+      "POST",
+      Base64String.from(signedRequest.getUri().toString()),
+      Base64String.from(GET_CALLER_IDENTITY_REQUEST_BODY),
+      Base64String.from(headersString)
+    );
+  }
+
+  private SdkHttpFullRequest signRequest(
+    final SdkHttpFullRequest getCallerIdentityRequest,
+    final AwsCredentials creds
+  ) {
+    final Region region = Region.of(vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.region);
+    Aws4SignerParams params = Aws4SignerParams.builder()
+      .awsCredentials(creds)
+      .signingName("sts")
+      .signingRegion(region)
+      .build();
+    return Aws4Signer.create().sign(getCallerIdentityRequest, params);
+  }
+
+  private AwsCredentials getAwsCredentials() {
+    try (DefaultCredentialsProvider defaultCredentialsProvider = DefaultCredentialsProvider.create()) {
+      return defaultCredentialsProvider.resolveCredentials();
+    }
+  }
+
+  private SdkHttpFullRequest buildGetCallerIdentityRequest() throws URISyntaxException {
+    final SdkHttpFullRequest.Builder builder = SdkHttpFullRequest.builder()
+      .method(SdkHttpMethod.POST)
+      .uri(new URI(vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.stsUrl))
+      .appendHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+      .appendHeader("Content-Length", String.valueOf(GET_CALLER_IDENTITY_REQUEST_BODY.length()))
+      .contentStreamProvider(() -> new ByteArrayInputStream(
+        StringHelper.stringToBytes(GET_CALLER_IDENTITY_REQUEST_BODY)
+      ));
+
+    vaultConfigHolder.getVaultBootstrapConfig().authentication.awsIam.vaultServerId.ifPresent(
+      serverId -> builder.appendHeader("X-Vault-AWS-IAM-Server-ID", serverId)
+    );
+
+    SdkHttpFullRequest request = builder.build();
+    // log request
+    return request;
   }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
@@ -51,6 +51,9 @@ public class VaultAuthenticationConfig {
     @ConfigItem
     public VaultKubernetesAuthenticationConfig kubernetes;
 
+    @ConfigItem
+    public VaultAwsIamAuthenticationConfig awsIam;
+
     public boolean isDirectClientToken() {
         return clientToken.isPresent() || clientTokenWrappingToken.isPresent();
     }
@@ -61,6 +64,10 @@ public class VaultAuthenticationConfig {
 
     public boolean isUserpass() {
         return userpass.username.isPresent() && (userpass.password.isPresent() || userpass.passwordWrappingToken.isPresent());
+    }
+
+    public boolean isAwsIam() {
+        return awsIam.stsUrl != null && awsIam.region != null && awsIam.role != null;
     }
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
@@ -72,7 +72,7 @@ public class VaultAuthenticationConfig {
     }
 
     public boolean isAwsIam() {
-        return awsIam.stsUrl != null && awsIam.region != null && awsIam.role != null;
+        return awsIam.stsUrl != null && awsIam.region.isPresent() && awsIam.role.isPresent();
     }
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
@@ -51,6 +51,11 @@ public class VaultAuthenticationConfig {
     @ConfigItem
     public VaultKubernetesAuthenticationConfig kubernetes;
 
+    /**
+     * AWS IAM authentication method
+     * <p>
+     * See https://developer.hashicorp.com/vault/docs/auth/aws
+     */
     @ConfigItem
     public VaultAwsIamAuthenticationConfig awsIam;
 

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
@@ -35,6 +35,21 @@ public enum VaultAuthenticationType {
     APPROLE,
 
 
+    /**
+     * AWS IAM vault authentication
+     * <p>
+     * The aws auth method provides an automated mechanism to retrieve a Vault token for IAM principals
+     * and AWS EC2 instances. Unlike most Vault auth methods, this method does not require manual first-deploying,
+     * or provisioning security-sensitive credentials (tokens, username/password, client certificates, etc),
+     * by operators under many circumstances.
+     * </p>
+     * <p>
+     * With the iam method, a special AWS request signed with AWS IAM credentials is used for authentication.
+     * The IAM credentials are automatically supplied to AWS instances in IAM instance profiles, Lambda functions,
+     * and others, and it is this information already provided by AWS which Vault can use to authenticate clients.
+     * </p>
+     * see https://developer.hashicorp.com/vault/api-docs/auth/aws
+     */
     AWS_IAM,
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
@@ -32,6 +32,9 @@ public enum VaultAuthenticationType {
      * <p>
      * https://www.vaultproject.io/api/auth/approle/index.html
      */
-    APPROLE
+    APPROLE,
+
+
+    AWS_IAM,
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
@@ -34,7 +34,6 @@ public enum VaultAuthenticationType {
      */
     APPROLE,
 
-
     /**
      * AWS IAM vault authentication
      * <p>

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
@@ -13,13 +13,13 @@ public class VaultAwsIamAuthenticationConfig {
      * ARN. This property is required when selecting the AWS IAM authentication type.
      */
     @ConfigItem
-    public String role;
+    public Optional<String> role;
 
     /**
      * The AWS region to use for AWS IAM authentication.
      */
     @ConfigItem
-    public String region;
+    public Optional<String> region;
 
     /**
      * The URL of the AWS STS endpoint to use for AWS IAM authentication.

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
@@ -1,0 +1,27 @@
+package io.quarkus.vault.runtime.config;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class VaultAwsIamAuthenticationConfig {
+
+    /**
+     * Aws iam authentication role that has been created in Vault to associate Vault policies, with
+     * aws iam service accounts. This property is required when selecting
+     * the aws iam authentication type.
+     */
+    @ConfigItem
+    public String role;
+
+    @ConfigItem
+    public String region;
+
+    @ConfigItem(defaultValue = "https://sts.amazonaws.com")
+    public String stsUrl;
+
+    @ConfigItem
+    public Optional<String> vaultServerId;
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
@@ -9,9 +9,8 @@ import io.quarkus.runtime.annotations.ConfigItem;
 public class VaultAwsIamAuthenticationConfig {
 
     /**
-     * Aws iam authentication role that has been created in Vault to associate Vault policies, with
-     * aws iam service accounts. This property is required when selecting
-     * the aws iam authentication type.
+     * AWS IAM authentication role that has been created in Vault to associate Vault policies, with
+     * ARN. This property is required when selecting the AWS IAM authentication type.
      */
     @ConfigItem
     public String role;

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
@@ -16,12 +16,33 @@ public class VaultAwsIamAuthenticationConfig {
     @ConfigItem
     public String role;
 
+    /**
+     * The AWS region to use for AWS IAM authentication.
+     */
     @ConfigItem
     public String region;
 
+    /**
+     * The URL of the AWS STS endpoint to use for AWS IAM authentication.
+     */
     @ConfigItem(defaultValue = "https://sts.amazonaws.com")
     public String stsUrl;
 
+    /**
+     * The Vault server ID to use for AWS IAM authentication.
+     */
     @ConfigItem
     public Optional<String> vaultServerId;
+
+    /**
+     * The AWS access key ID to use for AWS IAM authentication.
+     */
+    @ConfigItem
+    public Optional<String> awsAccessKey;
+
+    /**
+     * The AWS secret access key to use for AWS IAM authentication.
+     */
+    @ConfigItem
+    public Optional<String> awsSecretKey;
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
@@ -296,12 +296,12 @@ public class VaultBootstrapConfig {
                 + logConfidentialityLevel.maskWithTolerance(authentication.appRole.secretId.orElse(""), LOW) + '\'' +
                 ", appRoleSecretIdWrappingToken='"
                 + logConfidentialityLevel.maskWithTolerance(authentication.appRole.secretIdWrappingToken.orElse(""), LOW) + '\''
-                + ", awsIamRole=" + authentication.awsIam.role
-          + ", awsIamSts=" + authentication.awsIam.stsUrl
-          + ", awsIamRegion=" + authentication.awsIam.region
-//          + ", awsIamVaultServerId" + logConfidentialityLevel.maskWithTolerance(authentication.awsIam.vaultServerId.orElse(""), LOW) + '\''
-          +
-                ", clientToken=" + logConfidentialityLevel.maskWithTolerance(authentication.clientToken.orElse(""), LOW) +
+                + ", awsIamRole='" + logConfidentialityLevel.maskWithTolerance(authentication.awsIam.role, LOW) + '\''
+                + ", awsIamSts=" + authentication.awsIam.stsUrl
+                + ", awsIamRegion=" + authentication.awsIam.region
+                + ", awsIamVaultServerId='"
+                + logConfidentialityLevel.maskWithTolerance(authentication.awsIam.vaultServerId.orElse(""), MEDIUM) + '\''
+                + ", clientToken=" + logConfidentialityLevel.maskWithTolerance(authentication.clientToken.orElse(""), LOW) +
                 ", clientTokenWrappingToken="
                 + logConfidentialityLevel.maskWithTolerance(authentication.clientTokenWrappingToken.orElse(""), LOW) +
                 ", renewGracePeriod=" + renewGracePeriod +

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
@@ -39,7 +39,6 @@ public class VaultBootstrapConfig {
     public static final String DEFAULT_KUBERNETES_AUTH_MOUNT_PATH = "auth/kubernetes";
     public static final String DEFAULT_APPROLE_AUTH_MOUNT_PATH = "auth/approle";
 
-
     /**
      * Microprofile Config ordinal.
      * <p>
@@ -296,9 +295,10 @@ public class VaultBootstrapConfig {
                 + logConfidentialityLevel.maskWithTolerance(authentication.appRole.secretId.orElse(""), LOW) + '\'' +
                 ", appRoleSecretIdWrappingToken='"
                 + logConfidentialityLevel.maskWithTolerance(authentication.appRole.secretIdWrappingToken.orElse(""), LOW) + '\''
-                + ", awsIamRole='" + logConfidentialityLevel.maskWithTolerance(authentication.awsIam.role, LOW) + '\''
+                + ", awsIamRole='" + logConfidentialityLevel.maskWithTolerance(authentication.awsIam.role.orElse(""), LOW)
+                + '\''
                 + ", awsIamSts=" + authentication.awsIam.stsUrl
-                + ", awsIamRegion=" + authentication.awsIam.region
+                + ", awsIamRegion=" + authentication.awsIam.region.orElse("")
                 + ", awsIamVaultServerId='"
                 + logConfidentialityLevel.maskWithTolerance(authentication.awsIam.vaultServerId.orElse(""), MEDIUM) + '\''
                 + ", clientToken=" + logConfidentialityLevel.maskWithTolerance(authentication.clientToken.orElse(""), LOW) +

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
@@ -299,7 +299,7 @@ public class VaultBootstrapConfig {
                 + ", awsIamRole=" + authentication.awsIam.role
           + ", awsIamSts=" + authentication.awsIam.stsUrl
           + ", awsIamRegion=" + authentication.awsIam.region
-          + ", awsIamVaultServerId" + logConfidentialityLevel.maskWithTolerance(authentication.awsIam.vaultServerId.orElse(""), LOW) + '\''
+//          + ", awsIamVaultServerId" + logConfidentialityLevel.maskWithTolerance(authentication.awsIam.vaultServerId.orElse(""), LOW) + '\''
           +
                 ", clientToken=" + logConfidentialityLevel.maskWithTolerance(authentication.clientToken.orElse(""), LOW) +
                 ", clientTokenWrappingToken="

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultBootstrapConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.vault.runtime.config;
 import static io.quarkus.vault.runtime.LogConfidentialityLevel.LOW;
 import static io.quarkus.vault.runtime.LogConfidentialityLevel.MEDIUM;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.APPROLE;
+import static io.quarkus.vault.runtime.config.VaultAuthenticationType.AWS_IAM;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.KUBERNETES;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.USERPASS;
 
@@ -37,6 +38,7 @@ public class VaultBootstrapConfig {
     public static final String DEFAULT_TLS_USE_KUBERNETES_CACERT = "true";
     public static final String DEFAULT_KUBERNETES_AUTH_MOUNT_PATH = "auth/kubernetes";
     public static final String DEFAULT_APPROLE_AUTH_MOUNT_PATH = "auth/approle";
+
 
     /**
      * Microprofile Config ordinal.
@@ -267,6 +269,8 @@ public class VaultBootstrapConfig {
             return USERPASS;
         } else if (authentication.isAppRole()) {
             return APPROLE;
+        } else if (authentication.isAwsIam()) {
+            return AWS_IAM;
         } else {
             return null;
         }
@@ -292,7 +296,11 @@ public class VaultBootstrapConfig {
                 + logConfidentialityLevel.maskWithTolerance(authentication.appRole.secretId.orElse(""), LOW) + '\'' +
                 ", appRoleSecretIdWrappingToken='"
                 + logConfidentialityLevel.maskWithTolerance(authentication.appRole.secretIdWrappingToken.orElse(""), LOW) + '\''
-                +
+                + ", awsIamRole=" + authentication.awsIam.role
+          + ", awsIamSts=" + authentication.awsIam.stsUrl
+          + ", awsIamRegion=" + authentication.awsIam.region
+          + ", awsIamVaultServerId" + logConfidentialityLevel.maskWithTolerance(authentication.awsIam.vaultServerId.orElse(""), LOW) + '\''
+          +
                 ", clientToken=" + logConfidentialityLevel.maskWithTolerance(authentication.clientToken.orElse(""), LOW) +
                 ", clientTokenWrappingToken="
                 + logConfidentialityLevel.maskWithTolerance(authentication.clientTokenWrappingToken.orElse(""), LOW) +

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -41,6 +41,20 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>localstack</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>rabbitmq</artifactId>
             <exclusions>
                 <exclusion>

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
@@ -44,8 +44,8 @@ public class VaultTestLifecycleManager implements QuarkusTestResourceLifecycleMa
         sysprops.put("vault-test.password-kv-v2-wrapping-token", vaultTestExtension.passwordKvv2WrappingToken);
         sysprops.put("vault-test.another-password-kv-v2-wrapping-token", vaultTestExtension.anotherPasswordKvv2WrappingToken);
 
-        sysprops.put("vault-test.aws-user.access-key", vaultTestExtension.userAwsAccessKey.accessKey.accessKeyId);
-        sysprops.put("vault-test.aws-user.secret-key", vaultTestExtension.userAwsAccessKey.accessKey.secretAccessKey);
+        sysprops.put("vault-test.aws-user.access-key", vaultTestExtension.appAwsAccessKey.accessKey.accessKeyId);
+        sysprops.put("vault-test.aws-user.secret-key", vaultTestExtension.appAwsAccessKey.accessKey.secretAccessKey);
 
         log.info("using system properties " + sysprops);
 

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
@@ -44,6 +44,9 @@ public class VaultTestLifecycleManager implements QuarkusTestResourceLifecycleMa
         sysprops.put("vault-test.password-kv-v2-wrapping-token", vaultTestExtension.passwordKvv2WrappingToken);
         sysprops.put("vault-test.another-password-kv-v2-wrapping-token", vaultTestExtension.anotherPasswordKvv2WrappingToken);
 
+        sysprops.put("vault-test.aws-user.access-key", vaultTestExtension.userAwsAccessKey.accessKey.accessKeyId);
+        sysprops.put("vault-test.aws-user.secret-key", vaultTestExtension.userAwsAccessKey.accessKey.secretAccessKey);
+
         log.info("using system properties " + sysprops);
 
         return sysprops;


### PR DESCRIPTION
This PR provides AWS IAM authentication mechanism for the Vault.

AWS client dependency is set as provided, so in order to use the authentication, the library must be on the application's dependency list. However, here I am not sure. Looks like the dependency must always be on classpath judging from the integration tests. Please, advice what would be the correct way to specify dependency here.

Integration test is added, which starts the Localstack container with STS and IAM services enabled. Please tell me if more tests are needed.

Relates to https://github.com/quarkiverse/quarkus-vault/issues/39