### PR TITLE
quarkiverse-parent 15

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.0.3.Final
+:quarkus-version: 3.2.0.Final
 :quarkus-vault-version: 3.0.0
 :maven-version: 3.8.1+
 

--- a/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
@@ -14,7 +14,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-vault_quarkus.vault.devservices
 
 [.description]
 --
-If DevServices has been explicitly enabled or disabled. DevServices is generally enabled by default, unless there is an existing configuration present. 
+If DevServices has been explicitly enabled or disabled. DevServices is generally enabled by default, unless there is an existing configuration present.
+
 When DevServices is enabled Quarkus will attempt to automatically configure and start a vault instance when running in Dev or Test mode and when Docker is running.
 
 ifdef::add-copy-button-to-env-var[]
@@ -47,8 +48,10 @@ a|icon:lock[title=Fixed at build time] [[quarkus-vault_quarkus.vault.devservices
 
 [.description]
 --
-Indicates if the Vault instance managed by Quarkus Dev Services is shared. When shared, Quarkus looks for running containers using label-based service discovery. If a matching container is found, it is used, and so a second one is not started. Otherwise, Dev Services for Vault starts a new container. 
-The discovery uses the `quarkus-dev-service-vault` label. The value is configured using the `service-name` property. 
+Indicates if the Vault instance managed by Quarkus Dev Services is shared. When shared, Quarkus looks for running containers using label-based service discovery. If a matching container is found, it is used, and so a second one is not started. Otherwise, Dev Services for Vault starts a new container.
+
+The discovery uses the `quarkus-dev-service-vault` label. The value is configured using the `service-name` property.
+
 Container sharing is only used in dev mode.
 
 ifdef::add-copy-button-to-env-var[]
@@ -65,7 +68,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-vault_quarkus.vault.devservices
 
 [.description]
 --
-The value of the `quarkus-dev-service-vault` label attached to the started container. This property is used when `shared` is set to `true`. In this case, before starting a container, Dev Services for Vault looks for a container with the `quarkus-dev-service-vault` label set to the configured value. If found, it will use this container instead of starting a new one. Otherwise it starts a new container with the `quarkus-dev-service-vault` label set to the specified value. 
+The value of the `quarkus-dev-service-vault` label attached to the started container. This property is used when `shared` is set to `true`. In this case, before starting a container, Dev Services for Vault looks for a container with the `quarkus-dev-service-vault` label set to the configured value. If found, it will use this container instead of starting a new one. Otherwise it starts a new container with the `quarkus-dev-service-vault` label set to the specified value.
+
 This property is used when you need multiple shared Vault instances.
 
 ifdef::add-copy-button-to-env-var[]
@@ -82,7 +86,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-vault_quarkus.vault.devservices
 
 [.description]
 --
-Optional fixed port the dev service will listen to. 
+Optional fixed port the dev service will listen to.
+
 If not defined, the port will be chosen randomly.
 
 ifdef::add-copy-button-to-env-var[]
@@ -147,8 +152,10 @@ a| [[quarkus-vault_quarkus.vault.config-ordinal]]`link:#quarkus-vault_quarkus.va
 
 [.description]
 --
-Microprofile Config ordinal. 
-This is provided as an alternative to the `config_ordinal` property defined by the specification, to make it easier and more natural for applications to override the default ordinal. 
+Microprofile Config ordinal.
+
+This is provided as an alternative to the `config_ordinal` property defined by the specification, to make it easier and more natural for applications to override the default ordinal.
+
 The default value is higher than the file system or jar ordinals, but lower than env vars.
 
 ifdef::add-copy-button-to-env-var[]
@@ -395,7 +402,8 @@ a| [[quarkus-vault_quarkus.vault.non-proxy-hosts]]`link:#quarkus-vault_quarkus.v
 
 [.description]
 --
-List of remote hosts that are not proxied when the client is configured to use a proxy. This list serves the same purpose as the JVM `nonProxyHosts` configuration. 
+List of remote hosts that are not proxied when the client is configured to use a proxy. This list serves the same purpose as the JVM `nonProxyHosts` configuration.
+
 Entries can use the _++*++_ wildcard character for pattern matching, e.g _++*++.example.com_ matches _www.example.com_.
 
 ifdef::add-copy-button-to-env-var[]
@@ -671,8 +679,10 @@ a| [[quarkus-vault_quarkus.vault.authentication.client-token-wrapping-token]]`li
 
 [.description]
 --
-Client token wrapped in a wrapping token, such as what is returned by: 
-vault token create -wrap-ttl=60s -policy=myapp 
+Client token wrapped in a wrapping token, such as what is returned by:
+
+vault token create -wrap-ttl=60s -policy=myapp
+
 client-token and client-token-wrapping-token are exclusive. Lease renewal does not apply.
 
 ifdef::add-copy-button-to-env-var[]
@@ -721,8 +731,10 @@ a| [[quarkus-vault_quarkus.vault.authentication.app-role.secret-id-wrapping-toke
 
 [.description]
 --
-Wrapping token containing a Secret Id, obtained from: 
-vault write -wrap-ttl=60s -f auth/approle/role/myapp/secret-id 
+Wrapping token containing a Secret Id, obtained from:
+
+vault write -wrap-ttl=60s -f auth/approle/role/myapp/secret-id
+
 secret-id and secret-id-wrapping-token are exclusive
 
 ifdef::add-copy-button-to-env-var[]
@@ -787,10 +799,14 @@ a| [[quarkus-vault_quarkus.vault.authentication.userpass.password-wrapping-token
 
 [.description]
 --
-Wrapping token containing a Password, obtained from: 
-vault kv get -wrap-ttl=60s secret/ 
-The key has to be 'password', meaning the password has initially been provisioned with: 
-vault kv put secret/ password= 
+Wrapping token containing a Password, obtained from:
+
+vault kv get -wrap-ttl=60s secret/
+
+The key has to be 'password', meaning the password has initially been provisioned with:
+
+vault kv put secret/ password=
+
 password and password-wrapping-token are exclusive
 
 ifdef::add-copy-button-to-env-var[]
@@ -860,7 +876,8 @@ a| [[quarkus-vault_quarkus.vault.tls.skip-verify]]`link:#quarkus-vault_quarkus.v
 
 [.description]
 --
-Allows to bypass certificate validation on TLS communications. 
+Allows to bypass certificate validation on TLS communications.
+
 If true this will allow TLS communications with Vault, without checking the validity of the certificate presented by Vault. This is discouraged in production because it allows man in the middle type of attacks.
 
 ifdef::add-copy-button-to-env-var[]
@@ -877,7 +894,8 @@ a| [[quarkus-vault_quarkus.vault.tls.ca-cert]]`link:#quarkus-vault_quarkus.vault
 
 [.description]
 --
-Certificate bundle used to validate TLS communications with Vault. 
+Certificate bundle used to validate TLS communications with Vault.
+
 The path to a pem bundle file, if TLS is required, and trusted certificates are not set through javax.net.ssl.trustStore system property.
 
 ifdef::add-copy-button-to-env-var[]

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/WiremockProxy.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/WiremockProxy.java
@@ -1,5 +1,9 @@
 package io.quarkus.vault;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
 import java.util.Collections;
 import java.util.Map;
 
@@ -7,10 +11,6 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 
 public class WiremockProxy implements QuarkusTestResourceLifecycleManager {
 

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultHealthResult.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultHealthResult.java
@@ -7,7 +7,8 @@ import io.quarkus.vault.runtime.client.dto.VaultModel;
 public class VaultHealthResult implements VaultModel {
 
     public boolean initialized;
-    public boolean sealed;
+    @JsonProperty("sealed")
+    public boolean sealedStatus;
     public boolean standby;
     @JsonProperty("performance_standby")
     public boolean performanceStandby;
@@ -25,7 +26,7 @@ public class VaultHealthResult implements VaultModel {
 
     @Override
     public String toString() {
-        return "VaultHealth{initialized: " + initialized + ", sealed: " + sealed + '}';
+        return "VaultHealth{initialized: " + initialized + ", sealed: " + sealedStatus + '}';
     }
 
 }

--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultSealStatusResult.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultSealStatusResult.java
@@ -8,7 +8,8 @@ public class VaultSealStatusResult implements VaultModel {
 
     public String type;
     public boolean initialized;
-    public boolean sealed;
+    @JsonProperty("sealed")
+    public boolean sealedStatus;
     public int t;
     public int n;
     public int progress;
@@ -26,7 +27,7 @@ public class VaultSealStatusResult implements VaultModel {
     public String toString() {
         return "VaultSealStatus{" +
                 "type: '" + type + '\'' +
-                ", sealed: " + sealed +
+                ", sealed: " + sealedStatus +
                 ", initialized: " + initialized +
                 '}';
     }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse</groupId>
     <artifactId>quarkiverse-parent</artifactId>
-    <version>13</version>
+    <version>15</version>
   </parent>
   <groupId>io.quarkiverse.vault</groupId>
   <artifactId>quarkus-vault-parent</artifactId>

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultSystemBackendManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultSystemBackendManager.java
@@ -71,7 +71,7 @@ public class VaultSystemBackendManager implements VaultSystemBackendReactiveEngi
                     vaultSealStatus.setNonce(vaultSealStatusResult.nonce);
                     vaultSealStatus.setProgress(vaultSealStatusResult.progress);
                     vaultSealStatus.setRecoverySeal(vaultSealStatusResult.recoverySeal);
-                    vaultSealStatus.setSealed(vaultSealStatusResult.sealed);
+                    vaultSealStatus.setSealed(vaultSealStatusResult.sealedStatus);
                     vaultSealStatus.setT(vaultSealStatusResult.t);
                     vaultSealStatus.setType(vaultSealStatusResult.type);
                     vaultSealStatus.setVersion(vaultSealStatusResult.version);
@@ -91,7 +91,7 @@ public class VaultSystemBackendManager implements VaultSystemBackendReactiveEngi
                     vaultHealthStatus.setPerformanceStandby(vaultHealthResult.performanceStandby);
                     vaultHealthStatus.setReplicationDrMode(vaultHealthResult.replicationDrMode);
                     vaultHealthStatus.setReplicationPerfMode(vaultHealthResult.replicationPerfMode);
-                    vaultHealthStatus.setSealed(vaultHealthResult.sealed);
+                    vaultHealthStatus.setSealed(vaultHealthResult.sealedStatus);
                     vaultHealthStatus.setServerTimeUtc(vaultHealthResult.serverTimeUtc);
                     vaultHealthStatus.setStandby(vaultHealthResult.standby);
                     vaultHealthStatus.setVersion(vaultHealthResult.version);

--- a/runtime/src/main/java/io/quarkus/vault/sys/VaultHealthStatus.java
+++ b/runtime/src/main/java/io/quarkus/vault/sys/VaultHealthStatus.java
@@ -1,9 +1,12 @@
 package io.quarkus.vault.sys;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class VaultHealthStatus {
 
     private boolean initialized;
-    private boolean sealed;
+    @JsonProperty("sealed")
+    private boolean sealedStatus;
     private boolean standby;
     private boolean performanceStandby;
     private String replicationPerfMode;
@@ -22,11 +25,11 @@ public class VaultHealthStatus {
     }
 
     public boolean isSealed() {
-        return sealed;
+        return sealedStatus;
     }
 
-    public void setSealed(boolean sealed) {
-        this.sealed = sealed;
+    public void setSealed(boolean sealedStatus) {
+        this.sealedStatus = sealedStatus;
     }
 
     public boolean isStandby() {
@@ -95,6 +98,6 @@ public class VaultHealthStatus {
 
     @Override
     public String toString() {
-        return "VaultHealth{initialized: " + initialized + ", sealed: " + sealed + '}';
+        return "VaultHealth{initialized: " + initialized + ", sealed: " + sealedStatus + '}';
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/sys/VaultSealStatus.java
+++ b/runtime/src/main/java/io/quarkus/vault/sys/VaultSealStatus.java
@@ -1,10 +1,13 @@
 package io.quarkus.vault.sys;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class VaultSealStatus {
 
     private String type;
     private boolean initialized;
-    private boolean sealed;
+    @JsonProperty("sealed")
+    private boolean sealedStatus;
     private int t;
     private int n;
     private int progress;
@@ -32,11 +35,11 @@ public class VaultSealStatus {
     }
 
     public boolean isSealed() {
-        return sealed;
+        return sealedStatus;
     }
 
-    public void setSealed(boolean sealed) {
-        this.sealed = sealed;
+    public void setSealed(boolean sealedStatus) {
+        this.sealedStatus = sealedStatus;
     }
 
     public int getT() {
@@ -115,7 +118,7 @@ public class VaultSealStatus {
     public String toString() {
         return "VaultSealStatus{" +
                 "type: '" + type + '\'' +
-                ", sealed: " + sealed +
+                ", sealed: " + sealedStatus +
                 '}';
     }
 

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -286,7 +286,7 @@ public class VaultTestExtension {
         execVault("vault operator unseal " + unsealKey);
 
         VaultSealStatusResult sealStatus = vaultInternalSystemBackend.systemSealStatus(vaultClient).await().indefinitely();
-        assertFalse(sealStatus.sealed);
+        assertFalse(sealStatus.sealedStatus);
 
         // userpass auth
         execVault("vault auth enable userpass");


### PR DESCRIPTION
needed to rename field `sealed` because of error generated in `impsort`: `(line 11,col 12) Parse error. Found "sealed", expected one of  "enum" "exports" "module" "open" "opens" "provides" "record" "requires" "strictfp" "to" "transitive" "uses" "with" "yield" <IDENTIFIER>
`