### PR TITLE
Generate quarkus-vault-bom

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -12,7 +12,6 @@
         <dependency>
             <groupId>io.quarkiverse.vault</groupId>
             <artifactId>quarkus-vault</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/vault-app/pom.xml
+++ b/integration-tests/vault-app/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>io.quarkiverse.vault</groupId>
             <artifactId>quarkus-vault</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <assertj.version>3.24.2</assertj.version>
     <wiremock.version>2.27.2</wiremock.version>
     <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>
+    <sundrio-maven-plugin.version>0.100.1</sundrio-maven-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -55,6 +56,26 @@
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock-standalone</artifactId>
         <version>${wiremock.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.vault</groupId>
+        <artifactId>quarkus-vault</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.vault</groupId>
+        <artifactId>quarkus-vault-deployment</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.vault</groupId>
+        <artifactId>quarkus-vault-model</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.quarkiverse.vault</groupId>
+        <artifactId>quarkus-test-vault</artifactId>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -82,5 +103,40 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>io.sundr</groupId>
+        <artifactId>sundr-maven-plugin</artifactId>
+        <version>${sundrio-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <inherited>false</inherited>
+            <goals>
+              <goal>generate-bom</goal>
+            </goals>
+            <configuration>
+              <boms>
+                <bom>
+                  <artifactId>quarkus-vault-bom</artifactId>
+                  <name>Quarkus Vault: BOM</name>
+                  <description>Centralized dependencyManagement for the Quarkus Vault extension</description>
+                  <properties>
+                    <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
+                    <sonar.skip>true</sonar.skip>
+                  </properties>
+                  <modules>
+                    <includes>
+                      <include>*:quarkus-vault-model</include>
+                      <include>*:quarkus-vault</include>
+                      <include>*:quarkus-vault-deployment</include>
+                    </includes>
+                  </modules>
+                </bom>
+              </boms>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>io.quarkiverse.vault</groupId>
             <artifactId>quarkus-vault-model</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>io.quarkiverse.vault</groupId>
             <artifactId>quarkus-vault</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
This creates a `quarkus-vault-bom` to facilitate overriding versions when used in a project with the `quarkus-bom`(the extension modules are [included in the quarkus-bom](https://github.com/quarkusio/quarkus-platform/blob/8a3f9bfd51b83af3f3b2b50c71c2e1a10a5aa153/generated-platform-project/quarkus-universe/bom/pom.xml#L7797-L7811)) 