### PR TITLE
Fix asciidoc warnings

### DIFF
--- a/docs/modules/ROOT/pages/vault-auth.adoc
+++ b/docs/modules/ROOT/pages/vault-auth.adoc
@@ -1,7 +1,7 @@
 = Working with HashiCorp Vault’s Authentication
 
 include::./includes/attributes.adoc[]
-:base-guide: xref:vault.adoc[Vault guide]
+:base-guide: xref:index.adoc[Vault guide]
 :root-token: s.5VUS8pte13RqekCB2fmMT3u2
 :client-token: s.s93BVzJPzBiIGuYJHBTkG8Uw
 :private-key: 123456

--- a/docs/modules/ROOT/pages/vault-datasource.adoc
+++ b/docs/modules/ROOT/pages/vault-datasource.adoc
@@ -226,7 +226,7 @@ of databases are supported, such as https://www.vaultproject.io/docs/secrets/dat
 First we need to enable the `database` secret engine, configure the `postgresql-database-plugin` and create
 the database role `mydbrole` (replace `10.0.0.3` by the actual host that is running the PostgreSQL container;
 for simplicity we disabled _TLS_ between Vault and the PostgreSQL database):
-[source,bash, subs=attributes+]
+[source,bash]
 ----
 vault secrets enable database
 

--- a/docs/modules/ROOT/pages/vault-datasource.adoc
+++ b/docs/modules/ROOT/pages/vault-datasource.adoc
@@ -1,7 +1,7 @@
 = Using HashiCorp Vault with Databases
 
 include::./includes/attributes.adoc[]
-:base-guide: xref:vault.adoc[Vault guide]
+:base-guide: xref:index.adoc[Vault guide]
 :root-token: s.5VUS8pte13RqekCB2fmMT3u2
 :config-file: application.properties
 

--- a/docs/modules/ROOT/pages/vault-pki.adoc
+++ b/docs/modules/ROOT/pages/vault-pki.adoc
@@ -4,7 +4,7 @@ include::./includes/attributes.adoc[]
 :root-token: s.5VUS8pte13RqekCB2fmMT3u2
 :client-token: s.s93BVzJPzBiIGuYJHBTkG8Uw
 :config-file: application.properties
-:base-guide: xref:vault.adoc[Vault guide]
+:base-guide: xref:index.adoc[Vault guide]
 
 Vault's PKI Secret Engine generates dynamic X.509 certificates. It allows services to get certificates without
 manually generating a private key and CSR, submitting to a CA, and waiting for signed certificate. The PKI secret

--- a/docs/modules/ROOT/pages/vault-transit.adoc
+++ b/docs/modules/ROOT/pages/vault-transit.adoc
@@ -4,7 +4,7 @@ include::./includes/attributes.adoc[]
 :root-token: s.5VUS8pte13RqekCB2fmMT3u2
 :client-token: s.s93BVzJPzBiIGuYJHBTkG8Uw
 :config-file: application.properties
-:base-guide: xref:vault.adoc[Vault guide]
+:base-guide: xref:index.adoc[Vault guide]
 
 Vault's Transit Secret Engine offers an "encryption as a service" functionality. It allows to store encryption
 keys into Vault, and provides services to encrypt/decrypt and sign/verify arbitrary pieces of data. This brings


### PR DESCRIPTION
Proof of all warnings gone:
<img width="305" alt="image" src="https://github.com/quarkiverse/quarkus-vault/assets/11942401/be152451-39e9-4a28-8518-749e765a0565">

Proof of warnings before this PR:
<img width="788" alt="image" src="https://github.com/quarkiverse/quarkus-vault/assets/11942401/1571e44f-893e-4ea8-a51a-1543d9bf878d">

@gastaldi @vsevel when you have a bit of time please review :)