### PR TITLE
Update Quarkus version on attributes.adoc file

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.4.1
+:quarkus-version: 3.4.2
 :quarkus-vault-version: 3.2.0
 :maven-version: 3.8.1+
 


### PR DESCRIPTION
The `dependabot` did an excelent automated job on updating the dependency of `Quarkus` framework to use for the project after checking the build process but missed to update the `attributes.adoc` file to set up the right version of used Quarkus framework 

