### PR TITLE
Use latest stable tools on Github actions with the maven wrapped version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,10 @@ name: Build
 
 on:
   push:
-    branches:
-      - "main"
+    branches-ignore:
+      - 'dependabot/**'
+      - 'wip/**'
+      - 'draft/**'
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'
@@ -13,6 +15,7 @@ on:
       - '*.txt'
       - '.all-contributorsrc'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'
@@ -21,6 +24,7 @@ on:
       - '*.adoc'
       - '*.txt'
       - '.all-contributorsrc'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -28,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11
@@ -43,11 +47,11 @@ jobs:
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           # refresh cache every month to avoid unlimited growth
           key: maven-repo-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
       - name: Build with Maven
-        run: mvn -B formatter:validate verify --file pom.xml -Dnative
+        run: ./mvnw -B formatter:validate verify --file pom.xml -Dnative

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -36,12 +36,12 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: current-repo
 
       - name: Checkout Ecosystem
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ env.ECOSYSTEM_CI_REPO }}
           path: ecosystem-ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11
@@ -39,7 +39,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
The purpose of this pull request is to update the `Github actions` to latest stable ones and use to wrapped stable `maven` version 3.9.5 distribution to for building the project on` Github actions CI`, also open the build on users  branches to be sure the build is stable before making a pull request and of course disable that build in case of dependent bot pushed, `wip` branches and draft onces 


- enable the build process on user branches 
- update `checkout` actions to the latest stable version 4
- update `cache` actions to the latest stable version 4
- update the `setup-java` actions to the latest stable version 3 
- update `Github actions` for snapshot and release
- enable build on branches intended  to make pull requests

