### PR TITLE
Update version of vault image to latest stable official image 1.15.0 

### DIFF
--- a/deployment/src/main/java/io/quarkus/vault/deployment/DevServicesVaultProcessor.java
+++ b/deployment/src/main/java/io/quarkus/vault/deployment/DevServicesVaultProcessor.java
@@ -30,7 +30,7 @@ import io.quarkus.vault.runtime.config.VaultBuildTimeConfig;
 
 public class DevServicesVaultProcessor {
     private static final Logger log = Logger.getLogger(DevServicesVaultProcessor.class);
-    private static final String VAULT_IMAGE = "vault:" + VaultVersions.VAULT_TEST_VERSION;
+    private static final String VAULT_IMAGE = "hashicorp/vault:" + VaultVersions.VAULT_TEST_VERSION;
     private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-vault";
     private static final String DEV_SERVICE_TOKEN = "root";
     private static final int VAULT_EXPOSED_PORT = 8200;
@@ -182,7 +182,7 @@ public class DevServicesVaultProcessor {
         private final Closeable closeable;
 
         public VaultInstance(String host, int port, String clientToken, Closeable closeable) {
-            this("http://" + host + ":" + port, clientToken, closeable);
+            this("https://" + host + ":" + port, clientToken, closeable);
         }
 
         public VaultInstance(String url, String clientToken, Closeable closeable) {

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultPKIITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultPKIITCase.java
@@ -17,6 +17,7 @@ import static org.testcontainers.shaded.org.bouncycastle.asn1.x509.Extension.sub
 
 import java.io.StringReader;
 import java.math.BigInteger;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
@@ -914,15 +915,15 @@ public class VaultPKIITCase {
     }
 
     @Test
-    public void testGetCAChain() throws Exception {
+    public void testGetCAChain() throws CertificateException {
         // Generate root CA in "pki"
         GenerateRootOptions genRootOptions = new GenerateRootOptions();
         genRootOptions.subjectCommonName = "root.example.com";
         GeneratedRootCertificate generatedRootCertificate = pkiSecretEngine.generateRoot(genRootOptions);
         assertNotNull(generatedRootCertificate.certificate);
 
-        // Ensure root CA's returns empty CA chain
-        assertTrue(pkiSecretEngine.getCertificateAuthorityChain().getCertificates().isEmpty());
+        // Ensure root CA's is not empty
+        assertFalse(pkiSecretEngine.getCertificateAuthorityChain().getCertificates().isEmpty());
 
         // Generate intermediate CA CSR in "pki2"
         VaultPKISecretEngine pkiSecretEngine2 = pkiSecretEngineFactory.engine("pki2");

--- a/runtime/src/main/java/io/quarkus/vault/VaultPKISecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultPKISecretEngine.java
@@ -262,11 +262,11 @@ public class VaultPKISecretEngine {
 
     /**
      * Generates a Certificate Signing Request and private key for the engine's CA.
-     *
+     * <p>
      * Use this to generate a CSR and for the engine's CA that can be used by another
      * CA to issue an intermediate CA certificate. After generating the intermediate CA
      * {@link #setSignedIntermediateCA(String)} must be used to set the engine's CA certificate.
-     *
+     * <p>
      * This will overwrite any previously existing CA private key for the engine.
      *
      * @see #setSignedIntermediateCA(String)
@@ -279,7 +279,7 @@ public class VaultPKISecretEngine {
 
     /**
      * Sets the engine's intermediate CA certificate, signed by another CA.
-     *
+     * <p>
      * After generating a CSR (via {@link #generateIntermediateCSR(GenerateIntermediateCSROptions)}),
      * this method must be used to set the engine's CA.
      *

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultVersions.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultVersions.java
@@ -2,6 +2,6 @@ package io.quarkus.vault.runtime;
 
 public class VaultVersions {
 
-    public static final String VAULT_TEST_VERSION = "1.10.0";
+    public static final String VAULT_TEST_VERSION = "1.15.0";
 
 }

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -111,7 +111,7 @@ public class VaultTestExtension {
     public static final String OUT_FILE = "/out";
     public static final String WRAPPING_TEST_PATH = "wrapping-test";
 
-    private static String CRUD_PATH = "crud";
+    private static final String CRUD_PATH = "crud";
 
     public GenericContainer vaultContainer;
     public PostgreSQLContainer postgresContainer;
@@ -284,7 +284,7 @@ public class VaultTestExtension {
     }
 
     private String getVaultImage() {
-        return "vault:" + VaultVersions.VAULT_TEST_VERSION;
+        return "hashicorp/vault:" + VaultVersions.VAULT_TEST_VERSION;
     }
 
     private void initVault() throws InterruptedException, IOException {


### PR DESCRIPTION
The main purpose of this pull request is to use the latest stable version of vault image on `hashicorp/vault` instead the already used one `vault`, as mentioned on https://hub.docker.com/_/vault/  that Upcoming in Vault 1.14, we will stop publishing official `Dockerhub` images and publish only our Verified Publisher images. Users of `Docker` images should pull from [hashicorp/vault](https://hub.docker.com/r/hashicorp/vault) instead of [vault](https://hub.docker.com/_/vault). Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/vault` on this pull request, an update of a recent version of `vault` can keep fresh the library and make it fit to the upcoming new changes and prevent the drastic changes when a lot of breaking changes happens on certain versions 

- Update the vault hub image to use `hashicorp/vault`
- Upgrade the vault version to 1.15.0 
- Use `https` instead of `http` for vault instance
- Use `CertificateException` for `testGetCAChain` and fix the broken test related to this chnage
- Make `CRUD_PATH`  variable final 
