### PR TITLE
Remove unnecessary  return statements on lambdas and encapsulate public fields with fluent accessors

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
@@ -260,13 +260,13 @@ Renew grace period duration.
 <p>
 This value if used to extend a lease before it expires its ttl, or recreate a new lease before the current
 lease reaches its max_ttl.
-By default Vault leaseDuration is equal to 7 days (ie: 168h or 604800s).
+By default, Vault leaseDuration is equal to 7 days (ie: 168h or 604800s).
 If a connection pool maxLifetime is set, it is reasonable to set the renewGracePeriod to be greater
 than the maxLifetime, so that we are sure we get a chance to renew leases before we reach the ttl.
 In any case you need to make sure there will be attempts to fetch secrets within the renewGracePeriod,
 because that is when the renewals will happen. This is particularly important for db dynamic secrets
 because if the lease reaches its ttl or max_ttl, the password of the db user will become invalid and
-it will be not longer possible to log in.
+it will be no longer possible to log in.
 This value should also be smaller than the ttl, otherwise that would mean that we would try to recreate
 leases all the time.
 
@@ -384,7 +384,7 @@ a| [[quarkus-vault_quarkus.vault.kv-secret-engine-version]]`link:#quarkus-vault_
 --
 Kv secret engine version.
 <p>
-see https://www.vaultproject.io/docs/secrets/kv/index.html
+see <a href="https://www.vaultproject.io/docs/secrets/kv/index.html">KV secrets engine</a>
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_KV_SECRET_ENGINE_VERSION+++[]
@@ -420,7 +420,7 @@ The secret properties would be fetched from Vault using a `GET` on
 `https://localhost:8200/v1/secret/data/config/myapp` for a KV secret engine v2 (or
 `https://localhost:8200/v1/secret/config/myapp` for a KV secret engine v1).
 <p>
-see https://www.vaultproject.io/docs/secrets/kv/index.html
+see <a href="https://www.vaultproject.io/docs/secrets/kv/index.html">KV secrets engine</a>
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_KV_SECRET_ENGINE_MOUNT_PATH+++[]
@@ -670,7 +670,7 @@ Vault Enterprise namespace
 <p>
 If set, this will add a `X-Vault-Namespace` header to all requests sent to the Vault server.
 <p>
-See https://www.vaultproject.io/docs/enterprise/namespaces
+See <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Enterprise namespaces</a>
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_ENTERPRISE_NAMESPACE+++[]

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultPKIITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultPKIITCase.java
@@ -307,24 +307,24 @@ public class VaultPKIITCase {
 
         // Sign the intermediate CA using "pki"
         SignIntermediateCAOptions options = new SignIntermediateCAOptions();
-        options.subjectCommonName = "test.example.com";
-        options.subjectOrganization = "Test Org";
-        options.subjectOrganizationalUnit = "Test Unit";
-        options.subjectStreetAddress = "123 Main Street";
-        options.subjectLocality = "New York";
-        options.subjectProvince = "NY";
-        options.subjectCountry = "USA";
-        options.subjectPostalCode = "10030";
-        options.subjectSerialNumber = "9876543210";
-        options.subjectAlternativeNames = singletonList("alt.example.com");
-        options.ipSubjectAlternativeNames = singletonList("1.2.3.4");
-        options.uriSubjectAlternativeNames = singletonList("ex:12345");
-        //options.otherSubjectAlternativeNames = singletonList("1.3.6.1.4.1.311.20.2.3;UTF8:test");
-        options.excludeCommonNameFromSubjectAlternativeNames = true;
-        options.timeToLive = "8760h";
-        options.maxPathLength = 3;
-        options.permittedDnsDomains = asList("subs1.example.com", "subs2.example.com");
-        options.useCSRValues = false;
+        options.subjectCommonName("test.example.com");
+        options.subjectOrganization("Test Org");
+        options.subjectOrganizationalUnit("Test Unit");
+        options.subjectStreetAddress("123 Main Street");
+        options.subjectLocality("New York");
+        options.subjectProvince("NY");
+        options.subjectCountry("USA");
+        options.subjectPostalCode("10030");
+        options.subjectSerialNumber("9876543210");
+        options.subjectAlternativeNames(singletonList("alt.example.com"));
+        options.ipSubjectAlternativeNames(singletonList("1.2.3.4"));
+        options.uriSubjectAlternativeNames(singletonList("ex:12345"));
+        //options.otherSubjectAlternativeNames(singletonList("1.3.6.1.4.1.311.20.2.3;UTF8:test"));
+        options.excludeCommonNameFromSubjectAlternativeNames(true);
+        options.timeToLive("8760h");
+        options.maxPathLength(3);
+        options.permittedDnsDomains(asList("subs1.example.com", "subs2.example.com"));
+        options.useCSRValues(false);
 
         SignedCertificate result = pkiSecretEngine.signIntermediateCA((String) csrResult.csr.getData(), options);
 

--- a/runtime/src/main/java/io/quarkus/vault/VaultSystemBackendEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultSystemBackendEngine.java
@@ -126,7 +126,9 @@ public class VaultSystemBackendEngine {
      * Get the info for a secret engine, including its type.
      *
      * @since Vault 1.10.0
-     * @see https://www.vaultproject.io/api-docs/system/mounts#get-the-configuration-of-a-secret-engine
+     * @see <a href="https://www.vaultproject.io/api-docs/system/mounts#get-the-configuration-of-a-secret-engine">
+     *      Get the configuration of a secret engine
+     *      </a>
      *
      * @param mount Name of the secret engine
      * @return current secret engine info

--- a/runtime/src/main/java/io/quarkus/vault/VaultSystemBackendReactiveEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultSystemBackendReactiveEngine.java
@@ -89,7 +89,9 @@ public interface VaultSystemBackendReactiveEngine {
      * Get the info for a secret engine, including its type.
      *
      * @since Vault 1.10.0
-     * @see https://www.vaultproject.io/api-docs/system/mounts#get-the-configuration-of-a-secret-engine
+     * @see <a href="https://www.vaultproject.io/api-docs/system/mounts#get-the-configuration-of-a-secret-engine">
+     *      Get the configuration of a secret engine
+     *      </a>
      *
      * @param mount Name of the secret engine
      * @return current secret engine info

--- a/runtime/src/main/java/io/quarkus/vault/pki/SignIntermediateCAOptions.java
+++ b/runtime/src/main/java/io/quarkus/vault/pki/SignIntermediateCAOptions.java
@@ -10,89 +10,89 @@ public class SignIntermediateCAOptions {
     /**
      * Specifies Common Name (CN) of the subject.
      */
-    public String subjectCommonName;
+    private String subjectCommonName;
 
     /**
      * Specifies Organization (O) of the subject.
      */
-    public String subjectOrganization;
+    private String subjectOrganization;
 
     /**
      * Specifies Organizational Unit (OU) of the subject.
      */
-    public String subjectOrganizationalUnit;
+    private String subjectOrganizationalUnit;
 
     /**
      * Specifies Street Address of the subject.
      */
-    public String subjectStreetAddress;
+    private String subjectStreetAddress;
 
     /**
      * Specifies Postal Code of the subject.
      */
-    public String subjectPostalCode;
+    private String subjectPostalCode;
 
     /**
      * Specifies Locality (L) of the subject.
      */
-    public String subjectLocality;
+    private String subjectLocality;
 
     /**
      * Specifies Province (ST) of the subject.
      */
-    public String subjectProvince;
+    private String subjectProvince;
 
     /**
      * Specifies Country (C) of the subject.
      */
-    public String subjectCountry;
+    private String subjectCountry;
 
     /**
      * Specifies the Serial Number (SERIALNUMBER) of the subject.
      */
-    public String subjectSerialNumber;
+    private String subjectSerialNumber;
 
     /**
      * Specifies Subject Alternative Names.
      * <p>
      * These can be host names or email addresses; they will be parsed into their respective fields.
      */
-    public List<String> subjectAlternativeNames;
+    private List<String> subjectAlternativeNames;
 
     /**
      * Flag determining if the Common Name (CN) of the subject will be included
      * by default in the Subject Alternative Names of issued certificates.
      */
-    public Boolean excludeCommonNameFromSubjectAlternativeNames;
+    private Boolean excludeCommonNameFromSubjectAlternativeNames;
 
     /**
      * Specifies IP Subject Alternative Names.
      */
-    public List<String> ipSubjectAlternativeNames;
+    private List<String> ipSubjectAlternativeNames;
 
     /**
      * Specifies URI Subject Alternative Names.
      */
-    public List<String> uriSubjectAlternativeNames;
+    private List<String> uriSubjectAlternativeNames;
 
     /**
      * Specifies custom OID/UTF8-string Subject Alternative Names.
      * <p>
      * The format is the same as OpenSSL: <oid>;<type>:<value> where the only current valid type is UTF8.
      */
-    public List<String> otherSubjectAlternativeNames;
+    private List<String> otherSubjectAlternativeNames;
 
     /**
      * Specifies time-to-live.
      * <p>
      * Value is specified as a string duration with time suffix. Hour is the largest supported suffix.
      */
-    public String timeToLive;
+    private String timeToLive;
 
     /**
      * Specifies the maximum path length for generated certificate.
      */
-    public Integer maxPathLength;
+    private Integer maxPathLength;
 
     /**
      * Flag determining if CSR values are used instead of configured default values.
@@ -105,116 +105,192 @@ public class SignIntermediateCAOptions {
      * <li>Extensions requested in the CSR will be copied into the issued certificate.</li>
      * </ul>
      */
-    public Boolean useCSRValues;
+    private Boolean useCSRValues;
 
     /**
      * DNS domains for which certificates are allowed to be issued or signed by this CA certificate. Subdomains
      * are allowed, as per RFC.
      */
-    public List<String> permittedDnsDomains;
+    private List<String> permittedDnsDomains;
 
     /**
      * Specifies returned format of certificate data. If unspecified it defaults
      * to {@link DataFormat#PEM}
      */
-    public DataFormat format;
+    private DataFormat format;
 
-    public SignIntermediateCAOptions setSubjectCommonName(String subjectCommonName) {
+    public SignIntermediateCAOptions subjectCommonName(String subjectCommonName) {
         this.subjectCommonName = subjectCommonName;
         return this;
     }
 
-    public SignIntermediateCAOptions setSubjectOrganization(String subjectOrganization) {
+    public SignIntermediateCAOptions subjectOrganization(String subjectOrganization) {
         this.subjectOrganization = subjectOrganization;
         return this;
     }
 
-    public SignIntermediateCAOptions setSubjectOrganizationalUnit(String subjectOrganizationalUnit) {
+    public SignIntermediateCAOptions subjectOrganizationalUnit(String subjectOrganizationalUnit) {
         this.subjectOrganizationalUnit = subjectOrganizationalUnit;
         return this;
     }
 
-    public SignIntermediateCAOptions setSubjectStreetAddress(String subjectStreetAddress) {
+    public SignIntermediateCAOptions subjectStreetAddress(String subjectStreetAddress) {
         this.subjectStreetAddress = subjectStreetAddress;
         return this;
     }
 
-    public SignIntermediateCAOptions setSubjectPostalCode(String subjectPostalCode) {
+    public SignIntermediateCAOptions subjectPostalCode(String subjectPostalCode) {
         this.subjectPostalCode = subjectPostalCode;
         return this;
     }
 
-    public SignIntermediateCAOptions setSubjectLocality(String subjectLocality) {
+    public SignIntermediateCAOptions subjectLocality(String subjectLocality) {
         this.subjectLocality = subjectLocality;
         return this;
     }
 
-    public SignIntermediateCAOptions setSubjectProvince(String subjectProvince) {
+    public SignIntermediateCAOptions subjectProvince(String subjectProvince) {
         this.subjectProvince = subjectProvince;
         return this;
     }
 
-    public SignIntermediateCAOptions setSubjectCountry(String subjectCountry) {
+    public SignIntermediateCAOptions subjectCountry(String subjectCountry) {
         this.subjectCountry = subjectCountry;
         return this;
     }
 
-    public SignIntermediateCAOptions setSubjectSerialNumber(String subjectSerialNumber) {
+    public SignIntermediateCAOptions subjectSerialNumber(String subjectSerialNumber) {
         this.subjectSerialNumber = subjectSerialNumber;
         return this;
     }
 
-    public SignIntermediateCAOptions setSubjectAlternativeNames(List<String> subjectAlternativeNames) {
+    public SignIntermediateCAOptions subjectAlternativeNames(List<String> subjectAlternativeNames) {
         this.subjectAlternativeNames = subjectAlternativeNames;
         return this;
     }
 
-    public SignIntermediateCAOptions setExcludeCommonNameFromSubjectAlternativeNames(
+    public SignIntermediateCAOptions excludeCommonNameFromSubjectAlternativeNames(
             Boolean excludeCommonNameFromSubjectAlternativeNames) {
         this.excludeCommonNameFromSubjectAlternativeNames = excludeCommonNameFromSubjectAlternativeNames;
         return this;
     }
 
-    public SignIntermediateCAOptions setIpSubjectAlternativeNames(
+    public SignIntermediateCAOptions ipSubjectAlternativeNames(
             List<String> ipSubjectAlternativeNames) {
         this.ipSubjectAlternativeNames = ipSubjectAlternativeNames;
         return this;
     }
 
-    public SignIntermediateCAOptions setUriSubjectAlternativeNames(
+    public SignIntermediateCAOptions uriSubjectAlternativeNames(
             List<String> uriSubjectAlternativeNames) {
         this.uriSubjectAlternativeNames = uriSubjectAlternativeNames;
         return this;
     }
 
-    public SignIntermediateCAOptions setOtherSubjectAlternativeNames(
+    public SignIntermediateCAOptions otherSubjectAlternativeNames(
             List<String> otherSubjectAlternativeNames) {
         this.otherSubjectAlternativeNames = otherSubjectAlternativeNames;
         return this;
     }
 
-    public SignIntermediateCAOptions setTimeToLive(String timeToLive) {
+    public SignIntermediateCAOptions timeToLive(String timeToLive) {
         this.timeToLive = timeToLive;
         return this;
     }
 
-    public SignIntermediateCAOptions setMaxPathLength(Integer maxPathLength) {
+    public SignIntermediateCAOptions maxPathLength(Integer maxPathLength) {
         this.maxPathLength = maxPathLength;
         return this;
     }
 
-    public SignIntermediateCAOptions setUseCSRValues(Boolean useCSRValues) {
+    public SignIntermediateCAOptions useCSRValues(Boolean useCSRValues) {
         this.useCSRValues = useCSRValues;
         return this;
     }
 
-    public SignIntermediateCAOptions setPermittedDnsDomains(List<String> permittedDnsDomains) {
+    public SignIntermediateCAOptions permittedDnsDomains(List<String> permittedDnsDomains) {
         this.permittedDnsDomains = permittedDnsDomains;
         return this;
     }
 
-    public SignIntermediateCAOptions setFormat(DataFormat format) {
+    public SignIntermediateCAOptions format(DataFormat format) {
         this.format = format;
         return this;
+    }
+
+    public String subjectCommonName() {
+        return subjectCommonName;
+    }
+
+    public String subjectOrganization() {
+        return subjectOrganization;
+    }
+
+    public String subjectOrganizationalUnit() {
+        return subjectOrganizationalUnit;
+    }
+
+    public String subjectStreetAddress() {
+        return subjectStreetAddress;
+    }
+
+    public String subjectPostalCode() {
+        return subjectPostalCode;
+    }
+
+    public String subjectLocality() {
+        return subjectLocality;
+    }
+
+    public String subjectProvince() {
+        return subjectProvince;
+    }
+
+    public String subjectCountry() {
+        return subjectCountry;
+    }
+
+    public String subjectSerialNumber() {
+        return subjectSerialNumber;
+    }
+
+    public List<String> subjectAlternativeNames() {
+        return subjectAlternativeNames;
+    }
+
+    public Boolean excludeCommonNameFromSubjectAlternativeNames() {
+        return excludeCommonNameFromSubjectAlternativeNames;
+    }
+
+    public List<String> ipSubjectAlternativeNames() {
+        return ipSubjectAlternativeNames;
+    }
+
+    public List<String> uriSubjectAlternativeNames() {
+        return uriSubjectAlternativeNames;
+    }
+
+    public List<String> otherSubjectAlternativeNames() {
+        return otherSubjectAlternativeNames;
+    }
+
+    public String timeToLive() {
+        return timeToLive;
+    }
+
+    public Integer maxPathLength() {
+        return maxPathLength;
+    }
+
+    public Boolean useCSRValues() {
+        return useCSRValues;
+    }
+
+    public List<String> permittedDnsDomains() {
+        return permittedDnsDomains;
+    }
+
+    public DataFormat format() {
+        return format;
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultPKIManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultPKIManager.java
@@ -163,26 +163,24 @@ public class VaultPKIManager implements VaultPKISecretReactiveEngine {
         body.expiry = options.expiry;
         body.disable = options.disable;
 
-        return vaultAuthManager.getClientToken(vaultClient).flatMap(token -> {
-            return vaultInternalPKISecretEngine.configCRL(vaultClient, token, mount, body);
-        });
+        return vaultAuthManager.getClientToken(vaultClient).flatMap(token -> vaultInternalPKISecretEngine
+                .configCRL(vaultClient, token, mount, body));
     }
 
     @Override
     public Uni<ConfigCRLOptions> readCRLConfig() {
-        return vaultAuthManager.getClientToken(vaultClient).flatMap(token -> {
-            return vaultInternalPKISecretEngine.readCRL(vaultClient, token, mount)
-                    .map(internalResult -> {
-                        checkDataValid(internalResult);
+        return vaultAuthManager.getClientToken(vaultClient).flatMap(token -> vaultInternalPKISecretEngine
+                .readCRL(vaultClient, token, mount)
+                .map(internalResult -> {
+                    checkDataValid(internalResult);
 
-                        VaultPKIConfigCRLData internalResultData = internalResult.data;
+                    VaultPKIConfigCRLData internalResultData = internalResult.data;
 
-                        ConfigCRLOptions result = new ConfigCRLOptions();
-                        result.expiry = internalResultData.expiry;
-                        result.disable = internalResultData.disable;
-                        return result;
-                    });
-        });
+                    ConfigCRLOptions result = new ConfigCRLOptions();
+                    result.expiry = internalResultData.expiry;
+                    result.disable = internalResultData.disable;
+                    return result;
+                }));
     }
 
     @Override
@@ -527,26 +525,26 @@ public class VaultPKIManager implements VaultPKISecretReactiveEngine {
     @Override
     public Uni<SignedCertificate> signIntermediateCA(String pemSigningRequest, SignIntermediateCAOptions options) {
         VaultPKISignIntermediateCABody body = new VaultPKISignIntermediateCABody();
-        body.format = dataFormatToFormat(options.format);
+        body.format = dataFormatToFormat(options.format());
         body.csr = pemSigningRequest;
-        body.subjectCommonName = options.subjectCommonName;
-        body.subjectAlternativeNames = stringListToCommaString(options.subjectAlternativeNames);
-        body.ipSubjectAlternativeNames = stringListToCommaString(options.ipSubjectAlternativeNames);
-        body.uriSubjectAlternativeNames = stringListToCommaString(options.uriSubjectAlternativeNames);
-        body.otherSubjectAlternativeNames = options.otherSubjectAlternativeNames;
-        body.timeToLive = options.timeToLive;
-        body.maxPathLength = options.maxPathLength;
-        body.excludeCommonNameFromSubjectAlternativeNames = options.excludeCommonNameFromSubjectAlternativeNames;
-        body.useCSRValues = options.useCSRValues;
-        body.permittedDnsDomains = options.permittedDnsDomains;
-        body.subjectOrganization = options.subjectOrganization;
-        body.subjectOrganizationalUnit = options.subjectOrganizationalUnit;
-        body.subjectStreetAddress = options.subjectStreetAddress;
-        body.subjectPostalCode = options.subjectPostalCode;
-        body.subjectLocality = options.subjectLocality;
-        body.subjectProvince = options.subjectProvince;
-        body.subjectCountry = options.subjectCountry;
-        body.subjectSerialNumber = options.subjectSerialNumber;
+        body.subjectCommonName = options.subjectCommonName();
+        body.subjectAlternativeNames = stringListToCommaString(options.subjectAlternativeNames());
+        body.ipSubjectAlternativeNames = stringListToCommaString(options.ipSubjectAlternativeNames());
+        body.uriSubjectAlternativeNames = stringListToCommaString(options.uriSubjectAlternativeNames());
+        body.otherSubjectAlternativeNames = options.otherSubjectAlternativeNames();
+        body.timeToLive = options.timeToLive();
+        body.maxPathLength = options.maxPathLength();
+        body.excludeCommonNameFromSubjectAlternativeNames = options.excludeCommonNameFromSubjectAlternativeNames();
+        body.useCSRValues = options.useCSRValues();
+        body.permittedDnsDomains = options.permittedDnsDomains();
+        body.subjectOrganization = options.subjectOrganization();
+        body.subjectOrganizationalUnit = options.subjectOrganizationalUnit();
+        body.subjectStreetAddress = options.subjectStreetAddress();
+        body.subjectPostalCode = options.subjectPostalCode();
+        body.subjectLocality = options.subjectLocality();
+        body.subjectProvince = options.subjectProvince();
+        body.subjectCountry = options.subjectCountry();
+        body.subjectSerialNumber = options.subjectSerialNumber();
 
         return vaultAuthManager.getClientToken(vaultClient).flatMap(token -> vaultInternalPKISecretEngine
                 .signIntermediateCA(vaultClient, token, mount, body)

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
@@ -10,7 +10,7 @@ public enum VaultAuthenticationType {
      * associating one or more vault policies, with one or more service accounts and one or more namespaces.
      * When selecting the kubernetes authentication type, specify the vault authentication role to use.
      * <p>
-     * see https://www.vaultproject.io/api/auth/kubernetes/index.html
+     * see <a href="https://www.vaultproject.io/api/auth/kubernetes/index.html">Kubernetes auth method (API)</a>
      */
     KUBERNETES,
 

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultEnterpriseConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultEnterpriseConfig.java
@@ -12,7 +12,7 @@ public interface VaultEnterpriseConfig {
      * <p>
      * If set, this will add a `X-Vault-Namespace` header to all requests sent to the Vault server.
      * <p>
-     * See https://www.vaultproject.io/docs/enterprise/namespaces
+     * See <a href="https://www.vaultproject.io/docs/enterprise/namespaces">Vault Enterprise namespaces</a>
      *
      * @asciidoclet
      */

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -82,13 +82,13 @@ public interface VaultRuntimeConfig {
      * <p>
      * This value if used to extend a lease before it expires its ttl, or recreate a new lease before the current
      * lease reaches its max_ttl.
-     * By default Vault leaseDuration is equal to 7 days (ie: 168h or 604800s).
+     * By default, Vault leaseDuration is equal to 7 days (ie: 168h or 604800s).
      * If a connection pool maxLifetime is set, it is reasonable to set the renewGracePeriod to be greater
      * than the maxLifetime, so that we are sure we get a chance to renew leases before we reach the ttl.
      * In any case you need to make sure there will be attempts to fetch secrets within the renewGracePeriod,
      * because that is when the renewals will happen. This is particularly important for db dynamic secrets
      * because if the lease reaches its ttl or max_ttl, the password of the db user will become invalid and
-     * it will be not longer possible to log in.
+     * it will be no longer possible to log in.
      * This value should also be smaller than the ttl, otherwise that would mean that we would try to recreate
      * leases all the time.
      *
@@ -166,7 +166,7 @@ public interface VaultRuntimeConfig {
     /**
      * Kv secret engine version.
      * <p>
-     * see https://www.vaultproject.io/docs/secrets/kv/index.html
+     * see <a href="https://www.vaultproject.io/docs/secrets/kv/index.html">KV secrets engine</a>
      *
      * @asciidoclet
      */
@@ -193,7 +193,7 @@ public interface VaultRuntimeConfig {
      * `https://localhost:8200/v1/secret/data/config/myapp` for a KV secret engine v2 (or
      * `https://localhost:8200/v1/secret/config/myapp` for a KV secret engine v1).
      * <p>
-     * see https://www.vaultproject.io/docs/secrets/kv/index.html
+     * see <a href="https://www.vaultproject.io/docs/secrets/kv/index.html">KV secrets engine</a>
      *
      * @asciidoclet
      */

--- a/runtime/src/main/java/io/quarkus/vault/secrets/totp/KeyConfiguration.java
+++ b/runtime/src/main/java/io/quarkus/vault/secrets/totp/KeyConfiguration.java
@@ -4,11 +4,11 @@ import java.util.Objects;
 
 public class KeyConfiguration {
 
-    private String accountName;
-    private String algorithm;
-    private int digits;
-    private String issuer;
-    private int period;
+    private final String accountName;
+    private final String algorithm;
+    private final int digits;
+    private final String issuer;
+    private final int period;
 
     public KeyConfiguration(String accountName, String algorithm, int digits, String issuer, int period) {
         this.accountName = accountName;

--- a/runtime/src/main/java/io/quarkus/vault/secrets/totp/KeyConfiguration.java
+++ b/runtime/src/main/java/io/quarkus/vault/secrets/totp/KeyConfiguration.java
@@ -59,13 +59,11 @@ public class KeyConfiguration {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("KeyConfiguration{");
-        sb.append("accountName='").append(accountName).append('\'');
-        sb.append(", algorithm='").append(algorithm).append('\'');
-        sb.append(", digits=").append(digits);
-        sb.append(", issuer='").append(issuer).append('\'');
-        sb.append(", period=").append(period);
-        sb.append('}');
-        return sb.toString();
+        return "KeyConfiguration{" + "accountName='" + accountName + '\'' +
+                ", algorithm='" + algorithm + '\'' +
+                ", digits=" + digits +
+                ", issuer='" + issuer + '\'' +
+                ", period=" + period +
+                '}';
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/transit/DecryptionRequest.java
+++ b/runtime/src/main/java/io/quarkus/vault/transit/DecryptionRequest.java
@@ -11,7 +11,7 @@ import io.quarkus.vault.VaultTransitSecretEngine;
  */
 public class DecryptionRequest extends VaultTransitBatchItem {
 
-    private String ciphertext;
+    private final String ciphertext;
 
     public DecryptionRequest(String ciphertext) {
         this(ciphertext, null);


### PR DESCRIPTION
The purpose of this pull request is to bring some practices for reducing the number of lines on a growing class, and apply some practices, with some formatting to make it more readable and less verbose, notice that the maven formatter plugged into the project is used to ensure the conformity of the formatting

- remove non necessary return statement on some lambdas
- replace a check of instance of by non nullable check
- remove duplicated cast  for List<?>
- encapsulated directly accessed public fields with fluent accessors 
