### PR TITLE
Class Literal implements annotation interface Private 

### DIFF
--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/Private.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/Private.java
@@ -10,7 +10,7 @@ import jakarta.inject.Qualifier;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Private {
 
-    class Literal extends AnnotationLiteral<Private> implements Private {
+    class Literal extends AnnotationLiteral<Private> {
         public static final Literal INSTANCE = new Literal();
 
         private Literal() {


### PR DESCRIPTION
The class Literal implements annotation interface Private, it's better to not implement an Annotation type declaration cannot have explicit superinterfaces, so better to remove it from parent interfaces of Literal 

 