### PR TITLE
Upgrade version of Wiremock to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <quarkus.version>3.4.2</quarkus.version>
     <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
     <assertj.version>3.24.2</assertj.version>
-    <wiremock.version>2.27.2</wiremock.version>
+    <wiremock.version>3.0.1</wiremock.version>
     <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>
     <sundrio-maven-plugin.version>0.101.0</sundrio-maven-plugin.version>
   </properties>


### PR DESCRIPTION
The purpose of this pull request is to move the version. of wiremock to the latest stable one 3.0.1 to get benefits of that much improvement and bug fixings


For more information about the release notes please refer to : https://github.com/wiremock/wiremock/releases/tag/3.2.0 and to get a deep insight since the last used version, please check https://github.com/wiremock/wiremock/compare/2.27.2...3.2.0

