### PR TITLE
Quarkus 3.5.0.CR1 + Don't use VertxRecorder to get Vertx instance

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.4.2
+:quarkus-version: 3.5.0.CR1
 :quarkus-vault-version: 3.2.0
 :maven-version: 3.8.1+
 

--- a/integration-tests/vault/pom.xml
+++ b/integration-tests/vault/pom.xml
@@ -13,6 +13,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultPKIITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultPKIITCase.java
@@ -4,16 +4,16 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.pkcs_9_at_extensionRequest;
+import static org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.rsaEncryption;
+import static org.bouncycastle.asn1.x509.Extension.nameConstraints;
+import static org.bouncycastle.asn1.x509.Extension.subjectAlternativeName;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.testcontainers.shaded.org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.pkcs_9_at_extensionRequest;
-import static org.testcontainers.shaded.org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.rsaEncryption;
-import static org.testcontainers.shaded.org.bouncycastle.asn1.x509.Extension.nameConstraints;
-import static org.testcontainers.shaded.org.bouncycastle.asn1.x509.Extension.subjectAlternativeName;
 
 import java.io.StringReader;
 import java.math.BigInteger;
@@ -27,23 +27,23 @@ import java.util.List;
 
 import jakarta.inject.Inject;
 
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.GeneralSubtree;
+import org.bouncycastle.asn1.x509.NameConstraints;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.shaded.org.bouncycastle.asn1.ASN1Encodable;
-import org.testcontainers.shaded.org.bouncycastle.asn1.x509.BasicConstraints;
-import org.testcontainers.shaded.org.bouncycastle.asn1.x509.Extensions;
-import org.testcontainers.shaded.org.bouncycastle.asn1.x509.GeneralName;
-import org.testcontainers.shaded.org.bouncycastle.asn1.x509.GeneralNames;
-import org.testcontainers.shaded.org.bouncycastle.asn1.x509.GeneralSubtree;
-import org.testcontainers.shaded.org.bouncycastle.asn1.x509.NameConstraints;
-import org.testcontainers.shaded.org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.testcontainers.shaded.org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
-import org.testcontainers.shaded.org.bouncycastle.cert.X509CertificateHolder;
-import org.testcontainers.shaded.org.bouncycastle.openssl.PEMParser;
-import org.testcontainers.shaded.org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -168,7 +168,7 @@ public class VaultPKIITCase {
                 .map(GeneralName::getName)
                 .map(ASN1Encodable::toString)
                 .collect(toList());
-        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [0]test]", "alt.example.com", "#01020304", "ex:12345"),
+        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [CONTEXT 0]test]", "alt.example.com", "#01020304", "ex:12345"),
                 subjectAlternativeNames);
 
         // Check timeToLive option
@@ -268,7 +268,7 @@ public class VaultPKIITCase {
                 .map(GeneralName::getName)
                 .map(ASN1Encodable::toString)
                 .collect(toList());
-        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [0]test]", "alt.example.com", "#01020304", "ex:12345"),
+        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [CONTEXT 0]test]", "alt.example.com", "#01020304", "ex:12345"),
                 subjectAlternativeNames);
 
         // Check keyType option
@@ -598,7 +598,7 @@ public class VaultPKIITCase {
                 .map(GeneralName::getName)
                 .map(ASN1Encodable::toString)
                 .collect(toList());
-        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [0]test]", "alt.example.com", "#01020304", "ex:12345"),
+        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [CONTEXT 0]test]", "alt.example.com", "#01020304", "ex:12345"),
                 subjectAlternativeNames);
 
         // Check timeToLive option
@@ -678,7 +678,7 @@ public class VaultPKIITCase {
                 .map(GeneralName::getName)
                 .map(ASN1Encodable::toString)
                 .collect(toList());
-        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [0]test]", "alt.example.com", "#01020304", "ex:12345"),
+        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [CONTEXT 0]test]", "alt.example.com", "#01020304", "ex:12345"),
                 subjectAlternativeNames);
 
         // Check timeToLive option
@@ -777,7 +777,7 @@ public class VaultPKIITCase {
                 .map(GeneralName::getName)
                 .map(ASN1Encodable::toString)
                 .collect(toList());
-        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [0]test]", "alt.example.com", "#01020304", "ex:12345"),
+        assertEquals(asList("[1.3.6.1.4.1.311.20.2.3, [CONTEXT 0]test]", "alt.example.com", "#01020304", "ex:12345"),
                 subjectAlternativeNames);
 
         // Check timeToLive option

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.4.2</quarkus.version>
+    <quarkus.version>3.5.0.CR1</quarkus.version>
     <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
     <assertj.version>3.24.2</assertj.version>
     <wiremock.version>3.0.1</wiremock.version>

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/SharedVertxVaultClient.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/SharedVertxVaultClient.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
@@ -14,7 +15,6 @@ import io.quarkus.arc.Arc;
 import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.VaultException;
 import io.quarkus.vault.runtime.VaultConfigHolder;
-import io.quarkus.vertx.runtime.VertxEventBusConsumerRecorder;
 import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
@@ -24,9 +24,9 @@ public class SharedVertxVaultClient extends VertxVaultClient {
 
     @Produces
     @Dependent
-    public static VertxVaultClient createSharedVaultClient() {
+    public static VertxVaultClient createSharedVaultClient(Instance<Vertx> vertx) {
         Annotation clientType;
-        if (VertxEventBusConsumerRecorder.getVertx() != null) {
+        if (vertx.isResolvable()) {
             clientType = Shared.Literal.INSTANCE;
         } else {
             clientType = Private.Literal.INSTANCE;
@@ -36,11 +36,11 @@ public class SharedVertxVaultClient extends VertxVaultClient {
 
     private final AtomicReference<WebClient> webClient = new AtomicReference<>();
 
-    public SharedVertxVaultClient(VaultConfigHolder vaultConfigHolder, TlsConfig tlsConfig) {
+    public SharedVertxVaultClient(VaultConfigHolder vaultConfigHolder, Vertx quarkusMutinyVertx, TlsConfig tlsConfig) {
         super(vaultConfigHolder.getVaultRuntimeConfig().url().orElseThrow(() -> new VaultException("no vault url provided")),
                 vaultConfigHolder.getVaultRuntimeConfig().enterprise().namespace(),
                 vaultConfigHolder.getVaultRuntimeConfig().readTimeout());
-        Vertx vertx = Vertx.newInstance(VertxEventBusConsumerRecorder.getVertx());
+        Vertx vertx = Vertx.newInstance(quarkusMutinyVertx.getDelegate());
         this.webClient.set(createHttpClient(vertx, vaultConfigHolder.getVaultRuntimeConfig(), tlsConfig));
     }
 


### PR DESCRIPTION
supersedes https://github.com/quarkiverse/quarkus-vault/pull/167 @geoand 
relates to https://github.com/quarkusio/quarkus-platform/pull/1002#issuecomment-1757889375 @gsmet 
strangely, I had to rework the assertions on the pki test. what do you think @kdubb ?