### PR TITLE
VaultKvManager: Convert using String.valueOf

### DIFF
--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultProxyITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultProxyITCase.java
@@ -38,6 +38,8 @@ class VaultProxyITCase {
         assertEquals(PROXY_HOST, host);
         assertEquals(PROXY_PORT, port);
         assertEquals("{hello=world}", kvSecretEngine.readSecret("foo").toString());
+        assertEquals("true", kvSecretEngine.readSecret("withBoolean").get("isTrue"));
+        assertNull(kvSecretEngine.readSecret("withNull").get("foo"));
     }
 
 }

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/WiremockVault.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/WiremockVault.java
@@ -30,6 +30,20 @@ public class WiremockVault implements QuarkusTestResourceLifecycleManager {
                         .withBody(
                                 "{\"request_id\":\"bf5245f4-f194-2b13-80b7-6cad145b8135\",\"lease_id\":\"\",\"renewable\":false,\"lease_duration\":2764800,\"wrap_info\":null,\"warnings\":null,\"auth\":null,"
                                         + "\"data\":{\"hello\":\"world\"}}")));
+        server.stubFor(get(urlEqualTo("/v1/secret/withBoolean"))
+                .withHeader("X-Vault-Namespace", equalTo("accounting"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"request_id\":\"bf5245f4-f194-2b13-80b7-6cad145b8135\",\"lease_id\":\"\",\"renewable\":false,\"lease_duration\":2764800,\"wrap_info\":null,\"warnings\":null,\"auth\":null,"
+                                        + "\"data\":{\"isTrue\":true}}")));
+        server.stubFor(get(urlEqualTo("/v1/secret/withNull"))
+                .withHeader("X-Vault-Namespace", equalTo("accounting"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"request_id\":\"bf5245f4-f194-2b13-80b7-6cad145b8135\",\"lease_id\":\"\",\"renewable\":false,\"lease_duration\":2764800,\"wrap_info\":null,\"warnings\":null,\"auth\":null,"
+                                        + "\"data\":{\"foo\":null}}")));
 
         return Collections.emptyMap();
     }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
@@ -55,7 +55,8 @@ public class VaultKvManager implements VaultKVSecretReactiveEngine {
     }
 
     private Map<String, String> convert(Map<String, Object> map) {
-        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue() != null ? String.valueOf(entry.getValue()) : null));
+        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+                entry -> entry.getValue() != null ? String.valueOf(entry.getValue()) : null));
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
@@ -55,7 +55,7 @@ public class VaultKvManager implements VaultKVSecretReactiveEngine {
     }
 
     private Map<String, String> convert(Map<String, Object> map) {
-        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> (String) entry.getValue()));
+        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue() != null ? String.valueOf(entry.getValue()) : null));
     }
 
     @Override


### PR DESCRIPTION
in private convert method use String.valueOf instead of String cast to convert value fetched from vault.

resolve quarkiverse/quarkus-vault#189