### PR TITLE
Support scalar value other than String from Vault

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -340,6 +340,11 @@ or jar ordinals, but lower than environment variables.
 This value can be changed using property `quarkus.vault.config-ordinal`.
 ====
 
+[NOTE]
+====
+Only scalar types are supported for secrets value from Vault.
+====
+
 == Programmatic access to the KV secret engine
 
 Sometimes secrets are retrieved from an arbitrary path that is known only at runtime through an application

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -174,6 +174,15 @@ public class VaultITCase {
     }
 
     @Test
+    public void configPropertyScalar() {
+        Config config = ConfigProviderResolver.instance().getConfig();
+        assertTrue(config.getValue("my-enabled", Boolean.class));
+        assertTrue(config.getOptionalValue("my-foo", String.class).isEmpty());
+        assertTrue(config.getOptionalValue("my-fooList", String.class).isEmpty());
+        assertTrue(config.getOptionalValue("my-fooMap", String.class).isEmpty());
+    }
+
+    @Test
     public void secret() {
         Map<String, String> secrets = kvSecretEngine.readSecret(APP_SECRET_PATH);
         assertEquals("{" + SECRET_KEY + "=" + SECRET_VALUE + "}", secrets.toString());
@@ -374,6 +383,9 @@ public class VaultITCase {
         VaultKvSecretJsonV1 fooJsonV1 = vaultInternalKvV1SecretEngine
                 .getSecretJson(vaultClient, clientToken, SECRET_PATH_V1, "foo-json").await().indefinitely();
         assertEquals("{hello={foo=bar}}", fooJsonV1.data.toString());
+        VaultKvSecretJsonV1 configJsonV1 = vaultInternalKvV1SecretEngine
+                .getSecretJson(vaultClient, clientToken, SECRET_PATH_V1, "config-json").await().indefinitely();
+        assertTrue((boolean) configJsonV1.data.get("isEnabled"));
 
         VaultKvSecretJsonV2 secretV2 = vaultInternalKvV2SecretEngine
                 .getSecretJson(vaultClient, clientToken, SECRET_PATH_V2, APP_SECRET_PATH).await()
@@ -387,6 +399,9 @@ public class VaultITCase {
         VaultKvSecretJsonV2 fooJsonV2 = vaultInternalKvV2SecretEngine
                 .getSecretJson(vaultClient, clientToken, SECRET_PATH_V2, "foo-json").await().indefinitely();
         assertEquals("{hello={foo=bar}}", fooJsonV2.data.data.toString());
+        VaultKvSecretJsonV2 configJsonV2 = vaultInternalKvV2SecretEngine
+                .getSecretJson(vaultClient, clientToken, SECRET_PATH_V2, "config-json").await().indefinitely();
+        assertTrue((boolean) configJsonV2.data.data.get("isEnabled"));
     }
 
     private void assertTokenUserPass(String clientToken) {

--- a/integration-tests/vault/src/test/resources/application-vault.properties
+++ b/integration-tests/vault/src/test/resources/application-vault.properties
@@ -1,10 +1,14 @@
 quarkus.vault.url=https://localhost:8200
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
-quarkus.vault.secret-config-kv-path=config
+quarkus.vault.secret-config-kv-path=config,config-json
 quarkus.vault.config-ordinal=300
 
 my-password=${password}
+my-enabled=${isEnabled}
+my-foo=${nullFoo}
+my-fooList=${fooList}
+my-fooMap=${fooMap}
 
 quarkus.vault.credentials-provider.static.kv-path=config
 quarkus.vault.credentials-provider.dynamic.database-credentials-role=mydbrole

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -266,6 +266,7 @@ public class VaultTestExtension {
                 .withClasspathResourceMapping("vault-tls.crt", "/tmp/vault-tls.crt", READ_ONLY)
                 .withClasspathResourceMapping("vault-postgres-creation.sql", TMP_VAULT_POSTGRES_CREATION_SQL_FILE, READ_ONLY)
                 .withClasspathResourceMapping("secret.json", "/tmp/secret.json", READ_ONLY)
+                .withClasspathResourceMapping("config.json", "/tmp/config.json", READ_ONLY)
                 .withCommand("server", "-log-level=debug", "-config=" + TMP_VAULT_CONFIG_JSON_FILE);
 
         vaultContainer.setPortBindings(Arrays.asList(VAULT_PORT + ":" + VAULT_PORT));
@@ -343,6 +344,7 @@ public class VaultTestExtension {
                 format("vault kv put %s/%s %s=%s", SECRET_PATH_V1, LIST_PATH + "/" + LIST_SUB_PATH, SECRET_KEY, SECRET_VALUE));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V1, APP_CONFIG_PATH, PASSWORD_PROPERTY_NAME, DB_PASSWORD));
         execVault(format("vault kv put %s/foo-json @/tmp/secret.json", SECRET_PATH_V1));
+        execVault(format("vault kv put %s/config-json @/tmp/config.json", SECRET_PATH_V1));
 
         // static secrets kv v2
         execVault(format("vault secrets enable -path=%s -version=2 kv", SECRET_PATH_V2));
@@ -351,6 +353,7 @@ public class VaultTestExtension {
                 format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, LIST_PATH + "/" + LIST_SUB_PATH, SECRET_KEY, SECRET_VALUE));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, APP_CONFIG_PATH, PASSWORD_PROPERTY_NAME, DB_PASSWORD));
         execVault(format("vault kv put %s/foo-json @/tmp/secret.json", SECRET_PATH_V2));
+        execVault(format("vault kv put %s/config-json @/tmp/config.json", SECRET_PATH_V2));
 
         // multi config
         execVault(format("vault kv put %s/multi/default1 color=blue size=XL", SECRET_PATH_V2));

--- a/test-framework/src/main/resources/config.json
+++ b/test-framework/src/main/resources/config.json
@@ -1,0 +1,13 @@
+{
+  "isEnabled": true,
+  "nullFoo": null,
+  "fooList": [
+    "foo1",
+    "foo2",
+    "foo3"
+  ],
+  "fooMap": {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}

--- a/test-framework/src/main/resources/vault.policy
+++ b/test-framework/src/main/resources/vault.policy
@@ -11,6 +11,10 @@ path "secret/data/config" {
   capabilities = ["read"]
 }
 
+path "secret/data/config-json" {
+  capabilities = ["read"]
+}
+
 # vault config source kv engine v2 with multi paths
 path "secret/data/multi/*" {
   capabilities = ["read"]
@@ -33,6 +37,10 @@ path "secret-v1/foo-json" {
 
 # vault config source kv engine v1
 path "secret-v1/config" {
+  capabilities = ["read"]
+}
+
+path "secret-v1/config-json" {
   capabilities = ["read"]
 }
 


### PR DESCRIPTION
This pull request modify the way VaultConfigSource fetches the values from Vault following recommendation made by @vsevel 
Now, it fetches the value as Object and convert it to String if type is not List or Map.  
null value is also managed.  
Also add a note in documentation to mention that list and map are not yet supported.

resolve quarkiverse/quarkus-vault#189