### PR TITLE
Revert to using HTTP when connecting to dev services containers

### DIFF
--- a/deployment/src/main/java/io/quarkus/vault/deployment/DevServicesVaultProcessor.java
+++ b/deployment/src/main/java/io/quarkus/vault/deployment/DevServicesVaultProcessor.java
@@ -182,7 +182,7 @@ public class DevServicesVaultProcessor {
         private final Closeable closeable;
 
         public VaultInstance(String host, int port, String clientToken, Closeable closeable) {
-            this("https://" + host + ":" + port, clientToken, closeable);
+            this("http://" + host + ":" + port, clientToken, closeable);
         }
 
         public VaultInstance(String url, String clientToken, Closeable closeable) {


### PR DESCRIPTION
This fixes dev services by using the correct scheme, HTTP, when connecting to automatically started dev services containers.

@vsevel I'm thinking we revert this to HTTP instead of passing the new `-dev-tls` flag and using HTTPS. My reasoning is just, as we've discussed previously, security products are generally updated slowly and the new flag requires Vault `1.12+`.

We could selectively enable TLS but we'd need to be figuring it out prior to container startup based on the image tag. It can be done it's just work I don't have time for and we need to get this back in working order.

Also, we really need to add a unit test that actually uses a proper "dev services" container. Unfortunately I'm swamped at the moment.