### PR TITLE
Support all tunable values for `updateTuneInfo`

### DIFF
--- a/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultTuneBody.java
+++ b/model/src/main/java/io/quarkus/vault/runtime/client/dto/sys/VaultTuneBody.java
@@ -1,5 +1,7 @@
 package io.quarkus.vault.runtime.client.dto.sys;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class VaultTuneBody {
@@ -12,7 +14,25 @@ public class VaultTuneBody {
     @JsonProperty("max_lease_ttl")
     public Long maxLeaseTimeToLive;
 
-    @JsonProperty("force_no_cache")
-    public Boolean forceNoCache;
+    @JsonProperty("audit_non_hmac_request_keys")
+    public List<String> auditNonHMACRequestKeys;
+
+    @JsonProperty("audit_non_hmac_response_keys")
+    public List<String> auditNonHMACResponseKeys;
+
+    @JsonProperty("listing_visibility")
+    public String listingVisibility;
+
+    @JsonProperty("passthrough_request_headers")
+    public List<String> passthroughRequestHeaders;
+
+    @JsonProperty("allowed_response_headers")
+    public List<String> allowedResponseHeaders;
+
+    @JsonProperty("allowed_managed_keys")
+    public List<String> allowedManagedKeys;
+
+    @JsonProperty("plugin_version")
+    public String pluginVersion;
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultSystemBackendManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultSystemBackendManager.java
@@ -197,10 +197,18 @@ public class VaultSystemBackendManager implements VaultSystemBackendReactiveEngi
     @Override
     public Uni<Void> updateTuneInfo(String mount, VaultTuneInfo tuneInfoUpdates) {
         VaultTuneBody body = new VaultTuneBody();
-        body.description = tuneInfoUpdates.getDescription();
         body.defaultLeaseTimeToLive = tuneInfoUpdates.getDefaultLeaseTimeToLive();
         body.maxLeaseTimeToLive = tuneInfoUpdates.getMaxLeaseTimeToLive();
-        body.forceNoCache = tuneInfoUpdates.getForceNoCache();
+        body.description = tuneInfoUpdates.getDescription();
+        body.auditNonHMACRequestKeys = tuneInfoUpdates.getAuditNonHMACRequestKeys();
+        body.auditNonHMACResponseKeys = tuneInfoUpdates.getAuditNonHMACResponseKeys();
+        body.listingVisibility = tuneInfoUpdates.getListingVisibility() != null
+                ? tuneInfoUpdates.getListingVisibility().name().toLowerCase()
+                : null;
+        body.passthroughRequestHeaders = tuneInfoUpdates.getPassthroughRequestHeaders();
+        body.allowedResponseHeaders = tuneInfoUpdates.getAllowedResponseHeaders();
+        body.allowedManagedKeys = tuneInfoUpdates.getAllowedManagedKeys();
+        body.pluginVersion = tuneInfoUpdates.getPluginVersion();
 
         return vaultAuthManager.getClientToken(vaultClient).flatMap(token -> {
             return vaultInternalSystemBackend.updateTuneInfo(vaultClient, token, mount, body);

--- a/runtime/src/main/java/io/quarkus/vault/sys/VaultTuneInfo.java
+++ b/runtime/src/main/java/io/quarkus/vault/sys/VaultTuneInfo.java
@@ -16,6 +16,7 @@ public class VaultTuneInfo {
     private List<String> passthroughRequestHeaders;
     private List<String> allowedResponseHeaders;
     private List<String> allowedManagedKeys;
+    private String pluginVersion;
 
     public String getDescription() {
         return description;
@@ -67,6 +68,18 @@ public class VaultTuneInfo {
         return allowedManagedKeys;
     }
 
+    /**
+     * Returns the plugin version.
+     *
+     * @apiNote This value is not returned by {@link io.quarkus.vault.VaultSystemBackendEngine#getTuneInfo(String)},
+     *          use {@link io.quarkus.vault.VaultSystemBackendEngine#getSecretEngineInfo(String)} instead.
+     *
+     * @return the plugin version
+     */
+    public String getPluginVersion() {
+        return pluginVersion;
+    }
+
     public VaultTuneInfo setMaxLeaseTimeToLive(Long maxLeaseTimeToLive) {
         this.maxLeaseTimeToLive = maxLeaseTimeToLive;
         return this;
@@ -76,6 +89,15 @@ public class VaultTuneInfo {
         return forceNoCache;
     }
 
+    /**
+     * Sets whether caching is disabled for this mount.
+     *
+     * @apiNote Updating this value using
+     *          {@link io.quarkus.vault.VaultSystemBackendEngine#updateTuneInfo(String, VaultTuneInfo)} is not supported
+     *          by the Vault API.
+     *
+     * @param forceNoCache true if caching is disabled for this mount
+     */
     public VaultTuneInfo setForceNoCache(Boolean forceNoCache) {
         this.forceNoCache = forceNoCache;
         return this;
@@ -113,6 +135,11 @@ public class VaultTuneInfo {
 
     public VaultTuneInfo setAllowedManagedKeys(List<String> allowedManagedKeys) {
         this.allowedManagedKeys = allowedManagedKeys;
+        return this;
+    }
+
+    public VaultTuneInfo setPluginVersion(String pluginVersion) {
+        this.pluginVersion = pluginVersion;
         return this;
     }
 }


### PR DESCRIPTION
`updateTuneInfo` now correctly updates all the fields available for tuning. Additionally, the missing plugin version was added to `VaultTuneInfo`.