### PR TITLE
Allow applying a read timeout to JDKVaultHttpClient

### DIFF
--- a/client/src/main/java/io/quarkus/vault/client/common/VaultRequest.java
+++ b/client/src/main/java/io/quarkus/vault/client/common/VaultRequest.java
@@ -368,6 +368,8 @@ public class VaultRequest<T> {
         var builder = new Builder<T>(operation, method);
         builder.baseUrl = baseUrl;
         builder.apiVersion = apiVersion;
+        builder.operation = operation;
+        builder.method = method;
         builder.path = path;
         builder.token = token;
         builder.namespace = namespace;
@@ -376,6 +378,7 @@ public class VaultRequest<T> {
         builder.headers = headers;
         builder.body = body;
         builder.expectedStatusCodes = expectedStatusCodes;
+        builder.timeout = timeout;
         builder.resultExtractor = resultExtractor;
         builder.logConfidentialityLevel = logConfidentialityLevel;
         return builder;

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientProducer.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientProducer.java
@@ -52,6 +52,7 @@ public class VaultClientProducer {
         var vaultClientBuilder = VaultClient.builder()
                 .baseUrl(config.url().orElseThrow(() -> new VaultException("no vault url provided")))
                 .executor(vaultHttpClient)
+                .requestTimeout(config.readTimeout())
                 .logConfidentialityLevel(config.logConfidentialityLevel());
 
         configureAuthentication(vaultClientBuilder, config);


### PR DESCRIPTION
Read timeout was previously set on the VertxVaultHttpClient client but not on JDK. This applies the read timeout to JDKVaultHttpClient

Fixes #253
