### PR TITLE
First time fetch in Vault Config Source done multiple times

### DIFF
--- a/client/src/main/java/io/quarkus/vault/client/http/jdk/JDKVaultHttpClient.java
+++ b/client/src/main/java/io/quarkus/vault/client/http/jdk/JDKVaultHttpClient.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeoutException;
 
@@ -53,6 +54,13 @@ public class JDKVaultHttpClient extends VaultHttpClient {
             return CompletableFuture.failedStage(new TimeoutException("HTTP connect time out: " + x.getMessage()));
         } else if (x instanceof HttpTimeoutException) {
             return CompletableFuture.failedStage(new TimeoutException("HTTP request time out: " + x.getMessage()));
+        } else if (x instanceof CompletionException) {
+            Throwable cause = x.getCause();
+            if (cause instanceof HttpConnectTimeoutException) {
+                return CompletableFuture.failedStage(new TimeoutException("HTTP connect time out: " + cause.getMessage()));
+            } else if (cause instanceof HttpTimeoutException) {
+                return CompletableFuture.failedStage(new TimeoutException("HTTP request time out: " + cause.getMessage()));
+            }
         }
         return CompletableFuture.failedStage(x);
     }


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-vault/issues/278

moved `firstTime = false;` above the call to `fetchSecretsFirstTime`
added a finally block on `cache.set(new VaultCacheEntry<>(properties));`
caught `HttpTimeoutException`

to reproduce, used toxiproxy with:
```
toxiproxy-cli create -l localhost:18200 -u localhost:8200  vault
toxiproxy-cli toxic add -t latency -a latency=5000 -a jitter=2000 vault
```

and configuration:
```
quarkus.vault.url=http://localhost:18200
quarkus.vault.mp-config-initial-attempts=3
quarkus.vault.secret-config-kv-path=myapps/vault-quickstart/config,myapps/vault-quickstart/config2
```