### PR TITLE
Use quarkus.tls.trust-all property directly

### DIFF
--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/MutinyVertxClientFactory.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/MutinyVertxClientFactory.java
@@ -5,7 +5,6 @@ import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.KUBERNETES_CACE
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.runtime.TlsConfig;
 import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.PemTrustOptions;
@@ -17,7 +16,7 @@ public class MutinyVertxClientFactory {
 
     private static final Logger log = Logger.getLogger(MutinyVertxClientFactory.class.getName());
 
-    public static WebClient createHttpClient(Vertx vertx, VaultRuntimeConfig vaultRuntimeConfig, TlsConfig tlsConfig) {
+    public static WebClient createHttpClient(Vertx vertx, VaultRuntimeConfig vaultRuntimeConfig, boolean globalTrustAll) {
 
         WebClientOptions options = new WebClientOptions()
                 .setConnectTimeout((int) vaultRuntimeConfig.connectTimeout().toMillis())
@@ -34,7 +33,7 @@ public class MutinyVertxClientFactory {
             options.setNonProxyHosts(vaultRuntimeConfig.nonProxyHosts().get());
         }
 
-        boolean trustAll = vaultRuntimeConfig.tls().skipVerify().orElseGet(() -> tlsConfig.trustAll);
+        boolean trustAll = vaultRuntimeConfig.tls().skipVerify().orElseGet(() -> globalTrustAll);
         if (trustAll) {
             skipVerify(options);
         } else if (vaultRuntimeConfig.tls().caCert().isPresent()) {

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientProducer.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientProducer.java
@@ -5,7 +5,8 @@ import java.nio.file.Path;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
 
-import io.quarkus.runtime.TlsConfig;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import io.quarkus.vault.client.VaultClient;
 import io.quarkus.vault.client.VaultException;
 import io.quarkus.vault.client.auth.VaultAppRoleAuthOptions;
@@ -25,11 +26,12 @@ public class VaultClientProducer {
     @Produces
     @Singleton
     @Private
-    public VaultClient privateVaultClient(VaultConfigHolder vaultConfigHolder, TlsConfig tlsConfig) {
+    public VaultClient privateVaultClient(VaultConfigHolder vaultConfigHolder,
+            @ConfigProperty(name = "quarkus.tls.trust-all") boolean globalTrustAll) {
 
         var config = vaultConfigHolder.getVaultRuntimeConfig();
 
-        var httpClient = JDKClientFactory.createHttpClient(config, tlsConfig);
+        var httpClient = JDKClientFactory.createHttpClient(config, globalTrustAll);
         var vaultHttpClient = new JDKVaultHttpClient(httpClient);
 
         return createVaultClient(vaultHttpClient, config);
@@ -37,11 +39,12 @@ public class VaultClientProducer {
 
     @Produces
     @Singleton
-    public VaultClient sharedVaultClient(Vertx vertx, VaultConfigHolder vaultConfigHolder, TlsConfig tlsConfig) {
+    public VaultClient sharedVaultClient(Vertx vertx, VaultConfigHolder vaultConfigHolder,
+            @ConfigProperty(name = "quarkus.tls.trust-all") boolean globalTrustAll) {
 
         var config = vaultConfigHolder.getVaultRuntimeConfig();
 
-        var webClient = MutinyVertxClientFactory.createHttpClient(vertx, config, tlsConfig);
+        var webClient = MutinyVertxClientFactory.createHttpClient(vertx, config, globalTrustAll);
         var vaultHttpClient = new VertxVaultHttpClient(webClient);
 
         return createVaultClient(vaultHttpClient, config);


### PR DESCRIPTION
This is done because with the advent of Quarkus 3.12 and the new TLS Registry, the TlsConfig config object is no longer valid.

By using the property we can now support all versions of Quarkus