### PR TITLE
Allow configuring different images for Postgres and RabbitMQ in testing

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.17.0
+:quarkus-version: 3.17.5
 :quarkus-vault-version: 4.1.0
 :maven-version: 3.8.1+
 


### PR DESCRIPTION
Fixes #315 

Let me know if there is a place where to test this.