### PR TITLE
Fix API parameter names

### DIFF
--- a/client/src/main/specs/sys/health.yaml
+++ b/client/src/main/specs/sys/health.yaml
@@ -8,13 +8,13 @@ operations:
 - name: statusCode
   method: HEAD
   path: health
-  queryFrom: [standbyOk, perfStandbyOk]
+  queryFrom: [standbyok, perfstandbyok]
   authenticated: false
   parameters:
-  - name: standbyOk
+  - name: standbyok
     type: Boolean
     includeNulls: false
-  - name: perfStandbyOk
+  - name: perfstandbyok
     type: Boolean
     includeNulls: false
 
@@ -28,13 +28,13 @@ operations:
 - name: info
   method: GET
   path: health
-  queryFrom: [standbyOk, perfStandbyOk]
+  queryFrom: [standbyok, perfstandbyok]
   authenticated: false
   parameters:
-  - name: standbyOk
+  - name: standbyok
     type: Boolean
     includeNulls: false
-  - name: perfStandbyOk
+  - name: perfstandbyok
     type: Boolean
     includeNulls: false
   result:
@@ -83,10 +83,10 @@ methods:
 - name: status
   returnType: java.util.concurrent.CompletionStage<$$.api.sys.health.VaultHealthStatus>
   parameters:
-    standbyOk: Boolean
-    perfStandbyOk: Boolean
+    standbyok: Boolean
+    perfstandbyok: Boolean
   body: |
-    return statusCode(standbyOk, perfStandbyOk).thenApply($health:T::fromStatusCode);
+    return statusCode(standbyok, perfstandbyok).thenApply($health:T::fromStatusCode);
   bodyArguments:
     health: <type>$$.api.sys.health.VaultHealthStatus
 

--- a/client/src/main/specs/sys/init.yaml
+++ b/client/src/main/specs/sys/init.yaml
@@ -36,7 +36,7 @@ types:
   properties:
   - name: pgpKeys
     type: java.util.List<String>
-  - name: rootTokenPGPKey
+  - name: rootTokenPgpKey
     type: String
   - name: secretShares
     type: Integer
@@ -48,7 +48,7 @@ types:
     type: Integer
   - name: recoveryThreshold
     type: Integer
-  - name: recoveryPGPKeys
+  - name: recoveryPgpKeys
     type: java.util.List<String>
 
 - name: Result
@@ -61,4 +61,3 @@ types:
     type: java.util.List<String>
   - name: rootToken
     type: String
-


### PR DESCRIPTION
This fixes the API spec files so that the generated parameters are named exactly like in the Vault API documentation, e.g. `standbyok` has to be all-lowercase and `root_token_p_g_p_key` had too many underscores.