### PR TITLE
use .readSecretJson in VaultCredentialsProvider

### DIFF
--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultCredentialsProvider.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultCredentialsProvider.java
@@ -56,7 +56,7 @@ public class VaultCredentialsProvider implements CredentialsProvider {
         }
 
         if (config.kvPath().isPresent()) {
-            String password = vaultKVSecretEngine.readSecret(config.kvPath().get()).get(config.kvKey());
+            String password = String.valueOf(vaultKVSecretEngine.readSecretJson(config.kvPath().get()).get(config.kvKey()));
             Map<String, String> result = new HashMap<>();
             result.put(PASSWORD_PROPERTY_NAME, password);
             return result;


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-vault/issues/327

I have tested this in my own fork of the repo, and confirmed it to be working.

---

Under `.getCredentials()`, the current code uses `.readSecret()` which will fail if the secret containing the password contains a null value, e.g.:

```
{
    "password": "foo",
    "someotherfield": null
}
```

This PR uses `.readSecretJson()` instead, which does not assume the secret's values are always String, and converts it to String using `String.valueOf()`.

One caveat is that it will no longer (implicitly) guarantee the password to never be null. I am open to suggestions on this point.