### PR TITLE
Support refresh of limited use tokens (num_use > 0)

### DIFF
--- a/client/src/main/java/io/quarkus/vault/client/auth/VaultAppRoleTokenProvider.java
+++ b/client/src/main/java/io/quarkus/vault/client/auth/VaultAppRoleTokenProvider.java
@@ -31,7 +31,7 @@ public class VaultAppRoleTokenProvider implements VaultTokenProvider {
                 .thenApply(res -> {
                     var auth = res.getAuth();
                     return VaultToken.from(auth.getClientToken(), auth.isRenewable(), auth.getLeaseDuration(),
-                            authRequest.getInstantSource());
+                            auth.getNumUses(), authRequest.getInstantSource());
                 });
     }
 }

--- a/client/src/main/java/io/quarkus/vault/client/auth/VaultKubernetesTokenProvider.java
+++ b/client/src/main/java/io/quarkus/vault/client/auth/VaultKubernetesTokenProvider.java
@@ -44,7 +44,7 @@ public class VaultKubernetesTokenProvider implements VaultTokenProvider {
                     .thenApply(res -> {
                         var auth = res.getAuth();
                         return VaultToken.from(auth.getClientToken(), auth.isRenewable(), auth.getLeaseDuration(),
-                                authRequest.getInstantSource());
+                                auth.getNumUses(), authRequest.getInstantSource());
                     });
         });
     }

--- a/client/src/main/java/io/quarkus/vault/client/auth/VaultTimeLimited.java
+++ b/client/src/main/java/io/quarkus/vault/client/auth/VaultTimeLimited.java
@@ -41,6 +41,19 @@ public abstract class VaultTimeLimited {
         return leaseDuration;
     }
 
+    /**
+     * Check if the token is valid, in the sense that using it for authentication
+     * *should* be successful.
+     * <p>
+     * This base class implementation checks if the token is expired, but subclasses
+     * may override this method to provide additional checks.
+     *
+     * @return true if the token is valid, false otherwise
+     */
+    public boolean isValid() {
+        return !isExpired();
+    }
+
     public boolean isExpired() {
         return instantSource.instant().isAfter(getExpiresAt());
     }

--- a/client/src/main/java/io/quarkus/vault/client/auth/VaultToken.java
+++ b/client/src/main/java/io/quarkus/vault/client/auth/VaultToken.java
@@ -1,10 +1,12 @@
 package io.quarkus.vault.client.auth;
 
 import static io.quarkus.vault.client.logging.LogConfidentialityLevel.LOW;
+import static java.lang.Math.max;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.quarkus.vault.client.logging.LogConfidentialityLevel;
 
@@ -12,43 +14,86 @@ public class VaultToken extends VaultTimeLimited {
 
     private final String clientToken;
     private final boolean fromCache;
+    private final AtomicInteger allowedUsesRemaining;
 
-    public static VaultToken from(String clientToken, boolean renewable, Duration leaseDuration, InstantSource instantSource) {
-        return new VaultToken(clientToken, renewable, leaseDuration, false, instantSource);
+    public static VaultToken from(String clientToken, boolean renewable, Duration leaseDuration, Integer allowedUsesRemaining,
+            InstantSource instantSource) {
+        return new VaultToken(clientToken, renewable, leaseDuration, allowedUsesRemaining, false, instantSource);
     }
 
-    public static VaultToken renewable(String clientToken, Duration leaseDuration, InstantSource instantSource) {
-        return from(clientToken, true, leaseDuration, instantSource);
+    public static VaultToken renewable(String clientToken, Duration leaseDuration, Integer allowedUsesRemaining,
+            InstantSource instantSource) {
+        return from(clientToken, true, leaseDuration, allowedUsesRemaining, instantSource);
     }
 
     public static VaultToken neverExpires(String clientToken, InstantSource instantSource) {
-        return from(clientToken, false, Duration.ofSeconds(Long.MAX_VALUE), instantSource);
+        return from(clientToken, false, Duration.ofSeconds(Long.MAX_VALUE), null, instantSource);
     }
 
-    public VaultToken(String clientToken, boolean renewable, Duration leaseDuration, boolean fromCache,
+    public VaultToken(String clientToken, boolean renewable, Duration leaseDuration, Integer allowedUsesRemaining,
+            boolean fromCache,
             InstantSource instantSource) {
         super(renewable, leaseDuration, instantSource);
         this.clientToken = clientToken;
         this.fromCache = fromCache;
+        this.allowedUsesRemaining = new AtomicInteger(
+                allowedUsesRemaining != null && allowedUsesRemaining > 0 ? allowedUsesRemaining : Integer.MAX_VALUE);
     }
 
     public VaultToken(String clientToken, boolean renewable, Duration leaseDuration, Instant created, boolean fromCache,
-            InstantSource instantSource) {
+            AtomicInteger allowedUsesRemaining, InstantSource instantSource) {
         super(renewable, leaseDuration, created, instantSource);
         this.clientToken = clientToken;
         this.fromCache = fromCache;
+        this.allowedUsesRemaining = allowedUsesRemaining;
     }
 
     public VaultToken cached() {
-        return new VaultToken(clientToken, isRenewable(), getLeaseDuration(), getCreated(), true, getInstantSource());
+        return new VaultToken(clientToken, isRenewable(), getLeaseDuration(), getCreated(), true, allowedUsesRemaining,
+                getInstantSource());
     }
 
     public String getClientToken() {
         return clientToken;
     }
 
+    public int getAllowedUsesRemaining() {
+        return allowedUsesRemaining.get();
+    }
+
+    public boolean hasAllowedUsesRemaining() {
+        return allowedUsesRemaining.get() > 0;
+    }
+
     public boolean isFromCache() {
         return fromCache;
+    }
+
+    /**
+     * Returns the client token for usage, decrementing the allowed uses remaining.
+     * <p>
+     * During normal operation, this method should always return the client token, as the remaining
+     * use count should be checked before calling this method. However, if the token is requested for use
+     * multiple times in parallel, it is possible that the use count will be exhausted between the check and the
+     * call to this method. In that case, the method will throw a {@link VaultTokenException}. The
+     * {@link io.quarkus.vault.client.VaultClient} implementation should handle this exception and retry the
+     * request, after obtaining a new token (if possible).
+     *
+     * @apiNote This ignores the token's expiration; it is the caller's responsibility to ensure the token has not expired.
+     * @return the client token
+     * @throws VaultTokenException if the token has no allowed uses remaining
+     */
+    public String getClientTokenForUsage() {
+        var remainingUses = allowedUsesRemaining.updateAndGet(remaining -> max(remaining - 1, -1));
+        if (remainingUses == -1) {
+            throw new VaultTokenException(VaultTokenException.Reason.TOKEN_USES_EXHAUSTED);
+        }
+        return clientToken;
+    }
+
+    @Override
+    public boolean isValid() {
+        return super.isValid() && hasAllowedUsesRemaining();
     }
 
     public String getConfidentialInfo(LogConfidentialityLevel level) {

--- a/client/src/main/java/io/quarkus/vault/client/auth/VaultTokenException.java
+++ b/client/src/main/java/io/quarkus/vault/client/auth/VaultTokenException.java
@@ -1,0 +1,27 @@
+package io.quarkus.vault.client.auth;
+
+import io.quarkus.vault.client.VaultException;
+
+public class VaultTokenException extends VaultException {
+
+    public enum Reason {
+        TOKEN_EXPIRED("Token has expired"),
+        TOKEN_USES_EXHAUSTED("Token has exhausted its allowed usages"),
+
+        ;
+
+        public final String message;
+
+        Reason(String message) {
+            this.message = message;
+        }
+    }
+
+    public final Reason reason;
+
+    public VaultTokenException(Reason reason) {
+        super(reason.message);
+        this.reason = reason;
+    }
+
+}

--- a/client/src/main/java/io/quarkus/vault/client/auth/VaultUserPassTokenProvider.java
+++ b/client/src/main/java/io/quarkus/vault/client/auth/VaultUserPassTokenProvider.java
@@ -31,7 +31,7 @@ public class VaultUserPassTokenProvider implements VaultTokenProvider {
                     .thenApply(res -> {
                         var auth = res.getAuth();
                         return VaultToken.from(auth.getClientToken(), auth.isRenewable(), auth.getLeaseDuration(),
-                                authRequest.getInstantSource());
+                                auth.getNumUses(), authRequest.getInstantSource());
                     });
         });
     }

--- a/client/src/main/java/io/quarkus/vault/client/common/VaultTracingExecutor.java
+++ b/client/src/main/java/io/quarkus/vault/client/common/VaultTracingExecutor.java
@@ -19,16 +19,16 @@ public class VaultTracingExecutor implements VaultRequestExecutor {
 
     @Override
     public <T> CompletionStage<VaultResponse<T>> execute(VaultRequest<T> request) {
-        log.info("Executing: " + request.getOperation() + lineSeparator() + getCurlFormattedRequest(request));
+        log.info("REQUEST: " + request.getOperation() + lineSeparator() + getCurlFormattedRequest(request));
         return delegate.execute(request)
                 .thenApply((response) -> {
-                    var message = "Response: " + request.getOperation() + lineSeparator() + getHTTPFormattedResponse(response)
+                    var message = "RESPONSE: " + request.getOperation() + lineSeparator() + getHTTPFormattedResponse(response)
                             + lineSeparator();
                     log.log(response.isSuccessful() ? Level.INFO : Level.WARNING, message);
                     return response;
                 })
                 .exceptionallyCompose(error -> {
-                    log.log(Level.SEVERE, "Request failed: " + error);
+                    log.log(Level.SEVERE, "EXCEPTION: " + error);
                     return CompletableFuture.failedStage(error);
                 });
     }

--- a/client/src/test/java/io/quarkus/vault/client/test/TickableInstantSource.java
+++ b/client/src/test/java/io/quarkus/vault/client/test/TickableInstantSource.java
@@ -4,11 +4,11 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
 
-public class TickableInstanceSource implements InstantSource {
+public class TickableInstantSource implements InstantSource {
 
     private Instant instant;
 
-    public TickableInstanceSource(Instant instant) {
+    public TickableInstantSource(Instant instant) {
         this.instant = instant;
     }
 

--- a/client/src/test/java/io/quarkus/vault/client/test/VaultClientTestExtension.java
+++ b/client/src/test/java/io/quarkus/vault/client/test/VaultClientTestExtension.java
@@ -3,10 +3,13 @@ package io.quarkus.vault.client.test;
 import static org.testcontainers.containers.BindMode.READ_ONLY;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.http.HttpClient;
 import java.security.MessageDigest;
 import java.util.HexFormat;
+import java.util.Optional;
+import java.util.logging.LogManager;
 
 import org.junit.jupiter.api.extension.*;
 import org.testcontainers.containers.Network;
@@ -62,6 +65,18 @@ public class VaultClientTestExtension implements BeforeAllCallback, AfterAllCall
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
+
+        Optional.ofNullable(System.getenv("TRACE_ENABLED"))
+                .ifPresent(logLevel -> {
+                    try {
+                        try (InputStream traceLogPropStream = Thread.currentThread().getContextClassLoader()
+                                .getResourceAsStream("trace-log.properties")) {
+                            LogManager.getLogManager().readConfiguration(traceLogPropStream);
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException("Failed to load trace-log.properties", e);
+                    }
+                });
 
         var annotation = extensionContext.getRequiredTestClass().getAnnotation(VaultClientTest.class);
 

--- a/client/src/test/resources/trace-log.properties
+++ b/client/src/test/resources/trace-log.properties
@@ -1,0 +1,5 @@
+handlers = java.util.logging.ConsoleHandler
+.level= INFO
+io.quarkus.vault.level = FINEST
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.SimpleFormatter.format=%4$s[%1$tM:%1$tS.%1$tN] %2$s:%n    %5$s%n

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.19.0
+:quarkus-version: 3.19.3
 :quarkus-vault-version: 4.2.1
 :maven-version: 3.8.1+
 


### PR DESCRIPTION
Fixes #338

While enhancing the test for caching tokens I realized supporting limited use tokens should be fairly straightforward.

@vsevel What do you think? The only tricky thing is that we copy token values (e.g., for caching) so I used an `AtomicReference` as a shared reference count. Other than that, I added `getClientTokenForUsage` to decrement the count when it's being used for authorization and overloaded the expiration tests to take into account it's max # of uses.

I added a test to the caching token provider tests suite that tests limited use tokens and it seems to perform as expected.

It does not attempt to `extend` limited use tokens that are over their use limit because from my investigation it doesn't seem that's allowed.

@alexjaravete Can you build this this locally and see if this "just works" for you?