### PR TITLE
Actually pass standby-ok config params to health check

### DIFF
--- a/runtime/src/main/java/io/quarkus/vault/runtime/health/VaultHealthCheck.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/health/VaultHealthCheck.java
@@ -27,13 +27,10 @@ public class VaultHealthCheck implements HealthCheck {
         final HealthCheckResponseBuilder builder = HealthCheckResponse.named("Vault connection health check");
 
         try {
-            Boolean standbyok = null;
-            Boolean perfstandbyok = null;
-            if (buildTimeConfig.health() != null) {
-                standbyok = buildTimeConfig.health().standByOk();
-                perfstandbyok = buildTimeConfig.health().performanceStandByOk();
-            }
-            var status = client.sys().health().status(standbyok, perfstandbyok)
+            boolean isStandByOk = this.buildTimeConfig.health().standByOk();
+            boolean isPerfStandByOk = this.buildTimeConfig.health().performanceStandByOk();
+
+            var status = client.sys().health().status(isStandByOk, isPerfStandByOk)
                     .toCompletableFuture().get();
 
             switch (status) {

--- a/runtime/src/main/java/io/quarkus/vault/runtime/health/VaultHealthCheck.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/health/VaultHealthCheck.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
 
 import io.quarkus.vault.client.VaultClient;
+import io.quarkus.vault.runtime.config.VaultBuildTimeConfig;
 
 @Readiness
 @Singleton
@@ -17,13 +18,22 @@ public class VaultHealthCheck implements HealthCheck {
     @Inject
     VaultClient client;
 
+    @Inject
+    VaultBuildTimeConfig buildTimeConfig;
+
     @Override
     public HealthCheckResponse call() {
 
         final HealthCheckResponseBuilder builder = HealthCheckResponse.named("Vault connection health check");
 
         try {
-            var status = client.sys().health().status()
+            Boolean standbyok = null;
+            Boolean perfstandbyok = null;
+            if (buildTimeConfig.health() != null) {
+                standbyok = buildTimeConfig.health().standByOk();
+                perfstandbyok = buildTimeConfig.health().performanceStandByOk();
+            }
+            var status = client.sys().health().status(standbyok, perfstandbyok)
                     .toCompletableFuture().get();
 
             switch (status) {


### PR DESCRIPTION
In #320 I already fixed an issue with letter casing for the two health check query params `standbyok` and `perfstandbyok`, now we noticed that these two options are never ever being used in production. `VaultHealthCheck#call` only calls the parameter-less `status()` method instead of the method accepting two parameters for `standbyok` and `perfstandbyok`, so the config parameters were actually ineffective altogether.

This PR fixes this behavior.