### PR TITLE
Support for multiple mount paths selectable with prefixes in kv engine and ConfigSource

### DIFF
--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultMultiMountPathConfigITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultMultiMountPathConfigITCase.java
@@ -1,0 +1,49 @@
+package io.quarkus.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkiverse/quarkus-vault/pull/381
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultMultiMountPathConfigITCase {
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-vault-multi-mount-path.properties", "application.properties"));
+
+    @Test
+    public void defaultMountPathAndDefaultPath() {
+        Config config = ConfigProviderResolver.instance().getConfig();
+        assertEquals("red", config.getValue("color", String.class));
+        assertEquals("XL", config.getValue("size", String.class));
+        assertEquals("3", config.getValue("weight", String.class));
+    }
+
+    @Test
+    public void defaultMountPathAndPrefixedPath() {
+        Config config = ConfigProviderResolver.instance().getConfig();
+        assertEquals("green", config.getValue("singer.color", String.class));
+        assertEquals("paul", config.getValue("singer.firstname", String.class));
+        assertEquals("simon", config.getValue("singer.lastname", String.class));
+        assertEquals("78", config.getValue("singer.age", String.class));
+    }
+
+    @Test
+    public void customMountPath() {
+        Config config = ConfigProviderResolver.instance().getConfig();
+        assertEquals("akfak", config.getValue("shared.kafka.accessKey", String.class));
+        assertEquals("dummy", config.getValue("shared.kafka.common.accessKey", String.class));
+        assertEquals("certificate", config.getValue("shared.kafka.auth", String.class));
+        assertEquals("myappdb", config.getValue("app.db.name", String.class));
+    }
+}

--- a/integration-tests/vault/src/test/resources/application-vault-multi-mount-path.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-multi-mount-path.properties
@@ -1,0 +1,14 @@
+quarkus.vault.url=https://localhost:8200
+quarkus.vault.authentication.userpass.username=bob
+quarkus.vault.authentication.userpass.password=sinclair
+quarkus.vault.secret-config-kv-path=multi/default1,multi/default2
+quarkus.vault.secret-config-kv-path.singer=multi/singer1,multi/singer2
+
+quarkus.vault.kv-secret-engine-mount-path."shared"=shared-secret
+quarkus.vault.kv-secret-engine-mount-path."app"=app-secret/app1
+
+quarkus.vault.secret-config-kv-path."shared.kafka"=common,dev/kafka
+quarkus.vault.secret-config-kv-path."shared.kafka.common"=common
+quarkus.vault.secret-config-kv-path."app.db"=database
+
+quarkus.tls.trust-all=true

--- a/runtime/src/main/java/io/quarkus/vault/VaultKVSecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultKVSecretEngine.java
@@ -26,7 +26,7 @@ public class VaultKVSecretEngine {
     }
 
     /**
-     * Provides the values stored in the Vault kv secret engine at a particular path.
+     * Provides the values stored in the Vault kv secret engine at a particular path with un-prefixed (default) mount path.
      * This is a shortcut to `readSecretJson(String)` when the secret value is a String, which is the common case.
      *
      * @param path in Vault, without the kv engine mount path
@@ -37,7 +37,23 @@ public class VaultKVSecretEngine {
     }
 
     /**
-     * Provides the values stored in the Vault kv secret engine at a particular path.
+     * Provides the values stored in the Vault kv secret engine at a particular path with prefixed mount path.
+     * This is a shortcut to `readSecretJson(String, String)` when the secret value is a String, which is the common case.
+     *
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
+     * @param path in Vault, without the kv engine mount path
+     * @return list of key value pairs stored at 'path' in Vault
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    public Map<String, String> readSecret(String prefix, String path) {
+        return engine.readSecret(prefix, path).await().indefinitely();
+    }
+
+    /**
+     * Provides the values stored in the Vault kv secret engine at a particular path with un-prefixed (default) mount path.
      *
      * @param path in Vault, without the kv engine mount path
      * @return list of key value pairs stored at 'path' in Vault
@@ -47,7 +63,22 @@ public class VaultKVSecretEngine {
     }
 
     /**
-     * Writes the secret at the given path. If the path does not exist, the secret will
+     * Provides the values stored in the Vault kv secret engine at a particular path with prefixed mount path.
+     *
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
+     * @param path in Vault, without the kv engine mount path
+     * @return list of key value pairs stored at 'path' in Vault
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    public Map<String, Object> readSecretJson(String prefix, String path) {
+        return engine.readSecretJson(prefix, path).await().indefinitely();
+    }
+
+    /**
+     * Writes the secret at the given path with un-prefixed (default) mount path. If the path does not exist, the secret will
      * be created. If not the new secret will be merged with the existing one.
      *
      * @param path in Vault, without the kv engine mount path
@@ -58,7 +89,23 @@ public class VaultKVSecretEngine {
     }
 
     /**
-     * Deletes the secret at the given path. It has no effect if no secret is currently
+     * Writes the secret at the given path with prefixed mount path. If the path does not exist, the secret will
+     * be created. If not the new secret will be merged with the existing one.
+     *
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
+     * @param path in Vault, without the kv engine mount path
+     * @param secret to write at path
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    public void writeSecret(String prefix, String path, Map<String, String> secret) {
+        engine.writeSecret(prefix, path, secret).await().indefinitely();
+    }
+
+    /**
+     * Deletes the secret at the given path with un-prefixed (default) mount path. It has no effect if no secret is currently
      * stored at path.
      *
      * @param path to delete
@@ -68,13 +115,43 @@ public class VaultKVSecretEngine {
     }
 
     /**
-     * List all paths under the specified path.
+     * Deletes the secret at the given path with prefixed mount path. It has no effect if no secret is currently
+     * stored at path.
+     *
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
+     * @param path to delete
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    public void deleteSecret(String prefix, String path) {
+        engine.deleteSecret(prefix, path).await().indefinitely();
+    }
+
+    /**
+     * List all paths under the specified path with un-prefixed (default) mount path.
      *
      * @param path to list
      * @return list of subpaths
      */
     public List<String> listSecrets(String path) {
         return engine.listSecrets(path).await().indefinitely();
+    }
+
+    /**
+     * List all paths under the specified path with prefixed mount path.
+     *
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
+     * @param path to list
+     * @return list of subpaths
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    public List<String> listSecrets(String prefix, String path) {
+        return engine.listSecrets(prefix, path).await().indefinitely();
     }
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/VaultKVSecretReactiveEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultKVSecretReactiveEngine.java
@@ -15,7 +15,7 @@ import io.smallrye.mutiny.Uni;
 public interface VaultKVSecretReactiveEngine {
 
     /**
-     * Provides the values stored in the Vault kv secret engine at a particular path.
+     * Provides the values stored in the Vault kv secret engine at a particular path with un-prefixed (default) mount path.
      * This is a shortcut to `readSecretJson(String)` when the secret value is a String, which is the common case.
      *
      * @param path in Vault, without the kv engine mount path
@@ -24,7 +24,18 @@ public interface VaultKVSecretReactiveEngine {
     Uni<Map<String, String>> readSecret(String path);
 
     /**
-     * Provides the values stored in the Vault kv secret engine at a particular path.
+     * Provides the values stored in the Vault kv secret engine at a particular path with prefixed mount path.
+     * This is a shortcut to `readSecretJson(String, String)` when the secret value is a String, which is the common case.
+     *
+     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param path in Vault, without the kv engine mount path
+     * @return list of key value pairs stored at 'path' in Vault
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    Uni<Map<String, String>> readSecret(String prefix, String path);
+
+    /**
+     * Provides the values stored in the Vault kv secret engine at a particular path with un-prefixed (default) mount path.
      *
      * @param path in Vault, without the kv engine mount path
      * @return list of key value pairs stored at 'path' in Vault
@@ -32,7 +43,17 @@ public interface VaultKVSecretReactiveEngine {
     Uni<Map<String, Object>> readSecretJson(String path);
 
     /**
-     * Writes the secret at the given path. If the path does not exist, the secret will
+     * Provides the values stored in the Vault kv secret engine at a particular path with prefixed mount path.
+     *
+     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param path in Vault, without the kv engine mount path
+     * @return list of key value pairs stored at 'path' in Vault
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    Uni<Map<String, Object>> readSecretJson(String prefix, String path);
+
+    /**
+     * Writes the secret at the given path with un-prefixed (default) mount path. If the path does not exist, the secret will
      * be created. If not the new secret will be merged with the existing one.
      *
      * @param path in Vault, without the kv engine mount path
@@ -41,7 +62,18 @@ public interface VaultKVSecretReactiveEngine {
     Uni<Void> writeSecret(String path, Map<String, String> secret);
 
     /**
-     * Deletes the secret at the given path. It has no effect if no secret is currently
+     * Writes the secret at the given path with prefixed mount path. If the path does not exist, the secret will
+     * be created. If not the new secret will be merged with the existing one.
+     *
+     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param path in Vault, without the kv engine mount path
+     * @param secret to write at path
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    Uni<Void> writeSecret(String prefix, String path, Map<String, String> secret);
+
+    /**
+     * Deletes the secret at the given path with un-prefixed (default) mount path. It has no effect if no secret is currently
      * stored at path.
      *
      * @param path to delete
@@ -49,11 +81,30 @@ public interface VaultKVSecretReactiveEngine {
     Uni<Void> deleteSecret(String path);
 
     /**
-     * List all paths under the specified path.
+     * Deletes the secret at the given path with prefixed mount path. It has no effect if no secret is currently
+     * stored at path.
+     *
+     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param path to delete
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    Uni<Void> deleteSecret(String prefix, String path);
+
+    /**
+     * List all paths under the specified path with un-prefixed (default) mount path.
      *
      * @param path to list
      * @return list of subpaths
      */
     Uni<List<String>> listSecrets(String path);
 
+    /**
+     * List all paths under the specified path with prefixed mount path.
+     *
+     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param path to list
+     * @return list of subpaths
+     * @throws IllegalArgumentException if mount path for given prefix is not configured
+     */
+    Uni<List<String>> listSecrets(String prefix, String path);
 }

--- a/runtime/src/main/java/io/quarkus/vault/VaultKVSecretReactiveEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultKVSecretReactiveEngine.java
@@ -27,7 +27,10 @@ public interface VaultKVSecretReactiveEngine {
      * Provides the values stored in the Vault kv secret engine at a particular path with prefixed mount path.
      * This is a shortcut to `readSecretJson(String, String)` when the secret value is a String, which is the common case.
      *
-     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
      * @param path in Vault, without the kv engine mount path
      * @return list of key value pairs stored at 'path' in Vault
      * @throws IllegalArgumentException if mount path for given prefix is not configured
@@ -45,7 +48,10 @@ public interface VaultKVSecretReactiveEngine {
     /**
      * Provides the values stored in the Vault kv secret engine at a particular path with prefixed mount path.
      *
-     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
      * @param path in Vault, without the kv engine mount path
      * @return list of key value pairs stored at 'path' in Vault
      * @throws IllegalArgumentException if mount path for given prefix is not configured
@@ -65,7 +71,10 @@ public interface VaultKVSecretReactiveEngine {
      * Writes the secret at the given path with prefixed mount path. If the path does not exist, the secret will
      * be created. If not the new secret will be merged with the existing one.
      *
-     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
      * @param path in Vault, without the kv engine mount path
      * @param secret to write at path
      * @throws IllegalArgumentException if mount path for given prefix is not configured
@@ -84,7 +93,10 @@ public interface VaultKVSecretReactiveEngine {
      * Deletes the secret at the given path with prefixed mount path. It has no effect if no secret is currently
      * stored at path.
      *
-     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
      * @param path to delete
      * @throws IllegalArgumentException if mount path for given prefix is not configured
      */
@@ -101,7 +113,10 @@ public interface VaultKVSecretReactiveEngine {
     /**
      * List all paths under the specified path with prefixed mount path.
      *
-     * @param prefix of mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config property
+     * @param prefix of selected mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"} config
+     *        property
+     *        or null which selects default mount path configured with {@code quarkus.vault.kv-secret-engine-mount-path} config
+     *        property
      * @param path to list
      * @return list of subpaths
      * @throws IllegalArgumentException if mount path for given prefix is not configured

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
@@ -26,11 +26,25 @@ public class VaultKvManager implements VaultKVSecretReactiveEngine {
 
     private final VaultSecretsKV1 kv1;
     private final VaultSecretsKV2 kv2;
+    private final Map<String, VaultSecretsKV1> kv1Prefix;
+    private final Map<String, VaultSecretsKV2> kv2Prefix;
     private final boolean isV1;
 
     public VaultKvManager(VaultClient vaultClient, VaultConfigHolder vaultConfigHolder) {
         this.kv1 = vaultClient.secrets().kv1(vaultConfigHolder.getVaultRuntimeConfig().kvSecretEngineMountPath());
         this.kv2 = vaultClient.secrets().kv2(vaultConfigHolder.getVaultRuntimeConfig().kvSecretEngineMountPath());
+        this.kv1Prefix = vaultConfigHolder
+            .getVaultRuntimeConfig()
+            .kvSecretEngineMountPathPrefix()
+            .entrySet()
+            .stream()
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> vaultClient.secrets().kv1(e.getValue())));
+        this.kv2Prefix = vaultConfigHolder
+            .getVaultRuntimeConfig()
+            .kvSecretEngineMountPathPrefix()
+            .entrySet()
+            .stream()
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> vaultClient.secrets().kv2(e.getValue())));
         this.isV1 = vaultConfigHolder.getVaultRuntimeConfig().kvSecretEngineVersion() == 1;
     }
 
@@ -38,34 +52,75 @@ public class VaultKvManager implements VaultKVSecretReactiveEngine {
         return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> (String) entry.getValue()));
     }
 
+    private VaultSecretsKV1 kv1(String prefix) {
+        var kv1 = prefix == null ? this.kv1 : kv1Prefix.get(prefix);
+        if (kv1 == null) {
+            throw new IllegalStateException("Invalid prefix \"" + prefix + "\" or missing config property quarkus.vault.kv-secret-engine-mount-path.\"" + prefix + "\"");
+        }
+        return kv1;
+    }
+
+    private VaultSecretsKV2 kv2(String prefix) {
+        var kv2 = prefix == null ? this.kv2 : kv2Prefix.get(prefix);
+        if (kv2 == null) {
+            throw new IllegalStateException("Invalid prefix \"" + prefix + "\" or missing config property quarkus.vault.kv-secret-engine-mount-path.\"" + prefix + "\"");
+        }
+        return kv2;
+    }
+
     @Override
     public Uni<Map<String, String>> readSecret(String path) {
-        return readSecretJson(path).map(this::convert);
+        return readSecret(null, path);
+    }
+
+    @Override
+    public Uni<Map<String, String>> readSecret(String prefix, String path) {
+        return readSecretJson(prefix, path).map(this::convert);
     }
 
     @Override
     public Uni<Map<String, Object>> readSecretJson(String path) {
-        return isV1 ? Uni.createFrom().completionStage(kv1.read(path))
-                : Uni.createFrom().completionStage(kv2.readSecret(path)).map(VaultSecretsKV2ReadSecretData::getData);
+        return readSecretJson(null, path);
+    }
+
+    @Override
+    public Uni<Map<String, Object>> readSecretJson(String prefix, String path) {
+        return isV1 ? Uni.createFrom().completionStage(kv1(prefix).read(path))
+                : Uni.createFrom().completionStage(kv2(prefix).readSecret(path)).map(VaultSecretsKV2ReadSecretData::getData);
     }
 
     @Override
     public Uni<Void> writeSecret(String path, Map<String, String> secret) {
+        return writeSecret(null, path, secret);
+    }
+
+    @Override
+    public Uni<Void> writeSecret(String prefix, String path, Map<String, String> secret) {
         var secretMap = secret.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> (Object) entry.getValue()));
-        return isV1 ? Uni.createFrom().completionStage(kv1.update(path, secretMap))
-                : Uni.createFrom().completionStage(kv2.updateSecret(path, null, secretMap)).map(r -> null);
+        return isV1 ? Uni.createFrom().completionStage(kv1(prefix).update(path, secretMap))
+                : Uni.createFrom().completionStage(kv2(prefix).updateSecret(path, null, secretMap)).map(r -> null);
     }
 
     @Override
     public Uni<Void> deleteSecret(String path) {
-        return isV1 ? Uni.createFrom().completionStage(kv1.delete(path))
-                : Uni.createFrom().completionStage(kv2.deleteSecret(path));
+        return deleteSecret(null, path);
+    }
+
+    @Override
+    public Uni<Void> deleteSecret(String prefix, String path) {
+        return isV1 ? Uni.createFrom().completionStage(kv1(prefix).delete(path))
+                : Uni.createFrom().completionStage(kv2(prefix).deleteSecret(path));
     }
 
     @Override
     public Uni<List<String>> listSecrets(String path) {
-        return isV1 ? Uni.createFrom().completionStage(kv1.list(path))
-                : Uni.createFrom().completionStage(kv2.listSecrets(path));
+        return listSecrets(null, path);
+    }
+
+    @Override
+    public Uni<List<String>> listSecrets(String prefix, String path) {
+        return isV1 ? Uni.createFrom().completionStage(kv1(prefix).list(path))
+                : Uni.createFrom().completionStage(kv2(prefix).listSecrets(path));
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
@@ -34,17 +34,17 @@ public class VaultKvManager implements VaultKVSecretReactiveEngine {
         this.kv1 = vaultClient.secrets().kv1(vaultConfigHolder.getVaultRuntimeConfig().kvSecretEngineMountPath());
         this.kv2 = vaultClient.secrets().kv2(vaultConfigHolder.getVaultRuntimeConfig().kvSecretEngineMountPath());
         this.kv1Prefix = vaultConfigHolder
-            .getVaultRuntimeConfig()
-            .kvSecretEngineMountPathPrefix()
-            .entrySet()
-            .stream()
-            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> vaultClient.secrets().kv1(e.getValue())));
+                .getVaultRuntimeConfig()
+                .kvSecretEngineMountPathPrefix()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> vaultClient.secrets().kv1(e.getValue())));
         this.kv2Prefix = vaultConfigHolder
-            .getVaultRuntimeConfig()
-            .kvSecretEngineMountPathPrefix()
-            .entrySet()
-            .stream()
-            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> vaultClient.secrets().kv2(e.getValue())));
+                .getVaultRuntimeConfig()
+                .kvSecretEngineMountPathPrefix()
+                .entrySet()
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> vaultClient.secrets().kv2(e.getValue())));
         this.isV1 = vaultConfigHolder.getVaultRuntimeConfig().kvSecretEngineVersion() == 1;
     }
 
@@ -55,7 +55,8 @@ public class VaultKvManager implements VaultKVSecretReactiveEngine {
     private VaultSecretsKV1 kv1(String prefix) {
         var kv1 = prefix == null ? this.kv1 : kv1Prefix.get(prefix);
         if (kv1 == null) {
-            throw new IllegalStateException("Invalid prefix \"" + prefix + "\" or missing config property quarkus.vault.kv-secret-engine-mount-path.\"" + prefix + "\"");
+            throw new IllegalStateException("Invalid prefix \"" + prefix
+                    + "\" or missing config property quarkus.vault.kv-secret-engine-mount-path.\"" + prefix + "\"");
         }
         return kv1;
     }
@@ -63,7 +64,8 @@ public class VaultKvManager implements VaultKVSecretReactiveEngine {
     private VaultSecretsKV2 kv2(String prefix) {
         var kv2 = prefix == null ? this.kv2 : kv2Prefix.get(prefix);
         if (kv2 == null) {
-            throw new IllegalStateException("Invalid prefix \"" + prefix + "\" or missing config property quarkus.vault.kv-secret-engine-mount-path.\"" + prefix + "\"");
+            throw new IllegalStateException("Invalid prefix \"" + prefix
+                    + "\" or missing config property quarkus.vault.kv-secret-engine-mount-path.\"" + prefix + "\"");
         }
         return kv2;
     }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -176,13 +176,16 @@ public interface VaultRuntimeConfig {
     int kvSecretEngineVersion();
 
     /**
-     * KV secret engine path.
+     * KV secret engine path for un-prefixed access and as a fallback for non-specified prefixed access.
      * <p>
      * This value is used when building the url path in the KV secret engine programmatic access
-     * (i.e. `VaultKVSecretEngine`) and the vault config source (i.e. fetching configuration properties from Vault).
+     * (i.e. `VaultKVSecretEngine`) for methods that don't take property prefix as 1st parameter
+     * and the vault config source (i.e. fetching configuration properties from Vault) for {@code quarkus.vault.secret-config-kv-path}
+     * configured paths (without prefix) or as a fallback for {@code quarkus.vault.secret-config-kv-path."prefix"} configured paths
+     * (with prefix) but for which the prefix is not configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"}.
      * <p>
      * For a v2 KV secret engine (default - see `kv-secret-engine-version property`)
-     * the full url is built from the expression `<url>/v1/</kv-secret-engine-mount-path>/data/...`.
+     * the full url is built from the expression `<url>/v1/<kv-secret-engine-mount-path>/data/...`.
      * <p>
      * With property `quarkus.vault.url=https://localhost:8200`, the following call
      * `vaultKVSecretEngine.readSecret("foo/bar")` would lead eventually to a `GET` on Vault with the following
@@ -201,6 +204,22 @@ public interface VaultRuntimeConfig {
      */
     @WithDefault(DEFAULT_KV_SECRET_ENGINE_MOUNT_PATH)
     String kvSecretEngineMountPath();
+
+    /**
+     * KV secret engine paths for prefixed access.
+     *
+     * <p>
+     * These values are used when building the url path in the KV secret engine programmatic access
+     * (i.e. `VaultKVSecretEngine`) for methods that take property prefix as 1st parameter
+     * and the vault config source (i.e. fetching configuration properties from Vault) for
+     * {@code quarkus.vault.secret-config-kv-path."prefix"} configured paths (with matching prefix).
+     * <p>
+     *
+     * @see #kvSecretEngineMountPath()
+     */
+    @WithName("kv-secret-engine-mount-path")
+    @ConfigDocMapKey("prefix")
+    Map<String, String> kvSecretEngineMountPathPrefix();
 
     /**
      * Transit secret engine mount path.
@@ -324,6 +343,7 @@ public interface VaultRuntimeConfig {
                 ", logConfidentialityLevel=" + logConfidentialityLevel() +
                 ", kvSecretEngineVersion=" + kvSecretEngineVersion() +
                 ", kvSecretEngineMountPath='" + kvSecretEngineMountPath() + '\'' +
+                ", kvSecretEngineMountPathPrefix='" + kvSecretEngineMountPathPrefix() + '\'' +
                 ", tlsSkipVerify=" + tls().skipVerify() +
                 ", tlsCaCert=" + tls().caCert() +
                 ", connectTimeout=" + connectTimeout() +

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -176,22 +176,28 @@ public interface VaultRuntimeConfig {
     int kvSecretEngineVersion();
 
     /**
-     * KV secret engine path for un-prefixed access and as a fallback for non-specified prefixed access.
+     * KV secret engine mount path for un-prefixed access and as a fallback for unmatched prefixed access.
      * <p>
      * This value is used when building the url path in the KV secret engine programmatic access
      * (i.e. `VaultKVSecretEngine`) for methods that don't take property prefix as 1st parameter
-     * and the vault config source (i.e. fetching configuration properties from Vault) for {@code quarkus.vault.secret-config-kv-path}
-     * configured paths (without prefix) or as a fallback for {@code quarkus.vault.secret-config-kv-path."prefix"} configured paths
-     * (with prefix) but for which the prefix is not configured with {@code quarkus.vault.kv-secret-engine-mount-path."prefix"}.
+     * and the vault config source (i.e. fetching configuration properties from Vault) for
+     * {@code quarkus.vault.secret-config-kv-path}
+     * configured paths (without prefix) or as a fallback for {@code quarkus.vault.secret-config-kv-path."prefix"} configured
+     * paths
+     * for which the prefix is not matched with any prefix specified by
+     * {@code quarkus.vault.kv-secret-engine-mount-path."prefix"}
+     * properties. The matching of prefixes is performed so that the longest prefix from
+     * {@code quarkus.vault.kv-secret-engine-mount-path."prefix"}
+     * which is a prefix of the prefix from {@code quarkus.vault.secret-config-kv-path."prefix"} is used (if any).
      * <p>
      * For a v2 KV secret engine (default - see `kv-secret-engine-version property`)
-     * the full url is built from the expression `<url>/v1/<kv-secret-engine-mount-path>/data/...`.
+     * the full url is built from the expression `<url>/v1/&lt;kv-secret-engine-mount-path&gt;/data/...`.
      * <p>
      * With property `quarkus.vault.url=https://localhost:8200`, the following call
      * `vaultKVSecretEngine.readSecret("foo/bar")` would lead eventually to a `GET` on Vault with the following
      * url: `https://localhost:8200/v1/secret/data/foo/bar`.
      * <p>
-     * With a KV secret engine v1, the url changes to: `<url>/v1/</kv-secret-engine-mount-path>/...`.
+     * With a KV secret engine v1, the url changes to: `<url>/v1/&lt;kv-secret-engine-mount-path&gt;/...`.
      * <p>
      * The same logic is applied to the Vault config source. With `quarkus.vault.secret-config-kv-path=config/myapp`
      * The secret properties would be fetched from Vault using a `GET` on
@@ -206,7 +212,7 @@ public interface VaultRuntimeConfig {
     String kvSecretEngineMountPath();
 
     /**
-     * KV secret engine paths for prefixed access.
+     * KV secret engine mount paths for prefixed access.
      *
      * <p>
      * These values are used when building the url path in the KV secret engine programmatic access

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -72,6 +72,8 @@ public class VaultTestExtension {
     public static final String VAULT_AUTH_APPROLE = "myapprole";
     public static final String SECRET_PATH_V1 = "secret-v1";
     public static final String SECRET_PATH_V2 = "secret";
+    public static final String SHARED_SECRET_PATH_V2 = "shared-secret";
+    public static final String APP_SECRET_PATH_V2 = "app-secret/app1";
     public static final String LIST_PATH = "hello";
     public static final String LIST_SUB_PATH = "world";
     public static final String EXPECTED_SUB_PATHS = "[" + LIST_SUB_PATH + "]";
@@ -337,6 +339,8 @@ public class VaultTestExtension {
 
         // static secrets kv v2
         execVault(format("vault secrets enable -path=%s -version=2 kv", SECRET_PATH_V2));
+        execVault(format("vault secrets enable -path=%s -version=2 kv", SHARED_SECRET_PATH_V2));
+        execVault(format("vault secrets enable -path=%s -version=2 kv", APP_SECRET_PATH_V2));
         execVault(format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, APP_SECRET_PATH, SECRET_KEY, SECRET_VALUE));
         execVault(
                 format("vault kv put %s/%s %s=%s", SECRET_PATH_V2, LIST_PATH + "/" + LIST_SUB_PATH, SECRET_KEY, SECRET_VALUE));
@@ -349,6 +353,11 @@ public class VaultTestExtension {
         execVault(format("vault kv put %s/multi/default2 color=red weight=3", SECRET_PATH_V2));
         execVault(format("vault kv put %s/multi/singer1 firstname=paul lastname=shaffer", SECRET_PATH_V2));
         execVault(format("vault kv put %s/multi/singer2 lastname=simon age=78 color=green", SECRET_PATH_V2));
+
+        // multi mount path
+        execVault(format("vault kv put %s/common accessKey=dummy auth=certificate", SHARED_SECRET_PATH_V2));
+        execVault(format("vault kv put %s/dev/kafka accessKey=akfak secretKey=changeme", SHARED_SECRET_PATH_V2));
+        execVault(format("vault kv put %s/database name=myappdb size=XL", APP_SECRET_PATH_V2));
 
         // wrapped
 

--- a/test-framework/src/main/resources/vault.policy
+++ b/test-framework/src/main/resources/vault.policy
@@ -20,6 +20,15 @@ path "secret/data/multi/*" {
   capabilities = ["read"]
 }
 
+# vault config source kv engine v2 with mount paths
+path "shared-secret/data/*" {
+  capabilities = ["read"]
+}
+
+path "app-secret/app1/data/*" {
+  capabilities = ["read"]
+}
+
 path "secret/metadata/hello/*" {
   capabilities = ["list"]
 }


### PR DESCRIPTION
Hi,

It is usual practice to organize secrets in vault using two or more mount paths. For example, one monut path for secrets shared among multiple applications, another mount path for secrets private to the application, etc...
Currenty it is imposible to configure quarkus-vault to retrive secrets using multiple mount paths or map them to config properties from multiple mount paths in the same app.
I therefore propose to extend the quarkus-vault with this possibility in a backward compatible way.
My proposal consists of the addition of the following map of configuration properties:

`quarkus.vault.kv-secret-engine-mount-path."prefix"`

Similar to existing map of `quarkus.vault.secret-config-kv-path."prefix"` properties, but it contains a single mount path per `prefix`. These mount paths, if configured, are used instead of default mount path configured with  `quarkus.vault.kv-secret-engine-mount-path` property when using the overloaded VaultKVSecret(Reactive)Engine methods that take the `prefix` as the 1st additional parameter, or when mapping secrets to config propertes in ConfigSource for paths configured with map of configuration properties:

`quarkus.vault.secret-config-kv-path."prefix"`
 
The following is the rule that pairs a path from `quarkus.vault.secret-config-kv-path."prefix"` with the mount path from `quarkus.vault.kv-secret-engine-mount-path."prefix"`:
 
Let's call the prefix in `quarkus.vault.secret-config-kv-path."prefix"` the `configPrefix` and let's call the prefix in `quarkus.vault.kv-secret-engine-mount-path."prefix"` the `mountPrefix`. The mount path used in combination with the config path is the one with the longest `mountPrefix` that is a prefix of the `configPrefix`, if any such exists or the default mount path configured with `quarkus.vault.kv-secret-engine-mount-path`.

For example, with the following configuration:

```
quarkus.vault.kv-secret-engine-mount-path."shared"=secret/shared
quarkus.vault.kv-secret-engine-mount-path."app1"=secret/app1

quarkus.vault.secret-config-kv-path."shared.kafka"=kafka
quarkus.vault.secret-config-kv-path."app1.db"=db
```

The keys from path (assuming v2 engine):

`/v1/secret/shared/data/kafka`

...will end up as config properties prefixed with `shared.kafka.*` and keys from path:

`/v1/secret/app1/data/db`

...will end up as config properties prefixed with `app1.db.*`

I came up with code changes to implement this feature and are contained in this PR. The start of them, of course, just to trigger some feedback.

So, WDYT?

Regards, Peter