### PR TITLE
Add config property to configure transit secret engine mount path

### DIFF
--- a/docs/modules/ROOT/pages/vault-transit.adoc
+++ b/docs/modules/ROOT/pages/vault-transit.adoc
@@ -159,6 +159,12 @@ quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 ----
 
+[NOTE]
+====
+By default Quarkus assumes that a _transit secret engine_ is mounted at path `transit/`.
+If that is not the case, please use properties `quarkus.vault.transit-secret-engine-mount-path` accordingly.
+====
+
 Note that you did not need to specify the existence of a particular encryption key in the configuration. You only
 do so in special cases such as specifying the key type for upsert, or changing the signature algorithm, ... Check the complete configuration for more
 information.

--- a/integration-tests/vault-app/src/main/resources/application.properties
+++ b/integration-tests/vault-app/src/main/resources/application.properties
@@ -3,6 +3,7 @@ quarkus.vault.url=http://localhost:8200
 quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.log-confidentiality-level=low
+quarkus.vault.transit-secret-engine-mount-path=transit-test
 
 # this will allow default ds to get dynamic credentials from vault
 quarkus.vault.credentials-provider.mydb.database-credentials-role=mydbrole

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultTransitITCase.java
@@ -26,6 +26,7 @@ import java.util.stream.IntStream;
 
 import jakarta.inject.Inject;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -81,6 +82,9 @@ public class VaultTransitITCase {
     VaultClient client;
     @Inject
     VaultTransitSecretEngine transitSecretEngine;
+
+    @ConfigProperty(name = "quarkus.vault.transit-secret-engine-mount-path", defaultValue = "transit")
+    String transitMountPath;
 
     @Test
     public void encryptionString() {
@@ -249,7 +253,7 @@ public class VaultTransitITCase {
     }
 
     private void rotate(String keyName) throws Exception {
-        client.secrets().transit().rotateKey(keyName, null)
+        client.secrets().transit(transitMountPath).rotateKey(keyName, null)
                 .toCompletableFuture().get();
     }
 

--- a/integration-tests/vault/src/test/resources/application-vault.properties
+++ b/integration-tests/vault/src/test/resources/application-vault.properties
@@ -3,6 +3,7 @@ quarkus.vault.authentication.userpass.username=bob
 quarkus.vault.authentication.userpass.password=sinclair
 quarkus.vault.secret-config-kv-path=config,config-json
 quarkus.vault.config-ordinal=300
+quarkus.vault.transit-secret-engine-mount-path=transit-test
 
 my-password=${password}
 my-enabled=${isEnabled}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultTransitManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultTransitManager.java
@@ -69,7 +69,7 @@ public class VaultTransitManager implements VaultTransitSecretReactiveEngine {
 
     @Inject
     public VaultTransitManager(VaultClient client, VaultConfigHolder configHolder) {
-        this.transit = client.secrets().transit();
+        this.transit = client.secrets().transit(configHolder.getVaultRuntimeConfig().transitSecretEngineMountPath());
         this.vaultConfigHolder = configHolder;
     }
 

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -32,6 +32,7 @@ public interface VaultRuntimeConfig {
     String DEFAULT_CONFIG_ORDINAL = "270";
     String DEFAULT_KUBERNETES_JWT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
     String DEFAULT_KV_SECRET_ENGINE_MOUNT_PATH = "secret";
+    String DEFAULT_TRANSIT_SECRET_ENGINE_MOUNT_PATH = "transit";
     String KV_SECRET_ENGINE_VERSION_V2 = "2";
     String DEFAULT_RENEW_GRACE_PERIOD = "1H";
     String DEFAULT_SECRET_CONFIG_CACHE_PERIOD = "10M";
@@ -200,6 +201,16 @@ public interface VaultRuntimeConfig {
      */
     @WithDefault(DEFAULT_KV_SECRET_ENGINE_MOUNT_PATH)
     String kvSecretEngineMountPath();
+
+    /**
+     * Transit secret engine mount path.
+     * <p>
+     * see https://www.vaultproject.io/docs/secrets/transit/index.html
+     *
+     * @asciidoclet
+     */
+    @WithDefault(DEFAULT_TRANSIT_SECRET_ENGINE_MOUNT_PATH)
+    String transitSecretEngineMountPath();
 
     /**
      * TLS

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -420,15 +420,15 @@ public class VaultTestExtension {
 
         // transit
 
-        execVault("vault secrets enable transit");
-        execVault(format("vault write -f transit/keys/%s", ENCRYPTION_KEY_NAME));
-        execVault(format("vault write -f transit/keys/%s", ENCRYPTION_KEY2_NAME));
-        execVault(format("vault write transit/keys/%s derived=true", ENCRYPTION_DERIVED_KEY_NAME));
-        execVault(format("vault write transit/keys/%s type=ecdsa-p256", SIGN_KEY_NAME));
-        execVault(format("vault write transit/keys/%s type=rsa-2048", SIGN_KEY2_NAME));
-        execVault(format("vault write transit/keys/%s type=ed25519 derived=true", SIGN_DERIVATION_KEY_NAME));
+        execVault("vault secrets enable -path=transit-test transit");
+        execVault(format("vault write -f transit-test/keys/%s", ENCRYPTION_KEY_NAME));
+        execVault(format("vault write -f transit-test/keys/%s", ENCRYPTION_KEY2_NAME));
+        execVault(format("vault write transit-test/keys/%s derived=true", ENCRYPTION_DERIVED_KEY_NAME));
+        execVault(format("vault write transit-test/keys/%s type=ecdsa-p256", SIGN_KEY_NAME));
+        execVault(format("vault write transit-test/keys/%s type=rsa-2048", SIGN_KEY2_NAME));
+        execVault(format("vault write transit-test/keys/%s type=ed25519 derived=true", SIGN_DERIVATION_KEY_NAME));
 
-        execVault("vault write transit/keys/jws type=ecdsa-p256");
+        execVault("vault write transit-test/keys/jws type=ecdsa-p256");
 
         // TOTP
 

--- a/test-framework/src/main/resources/vault.policy
+++ b/test-framework/src/main/resources/vault.policy
@@ -53,7 +53,7 @@ path "rabbitmq/creds/myrabbitmqrole" {
 }
 
 # transit
-path "transit/*" {
+path "transit-test/*" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
 #path "transit/encrypt/my-key" {


### PR DESCRIPTION
This adds `quarkus.vault.transit-secret-engine-mount-path` config property.

Behaviour is the same as `quarkus.vault.kv-secret-engine-mount-path`.