### PR TITLE
Support Multiple KV Secret Engines

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -345,6 +345,11 @@ This value can be changed using property `quarkus.vault.config-ordinal`.
 Only scalar types are supported for secrets value from Vault.
 ====
 
+[NOTE]
+====
+It is possible to create named KV secret engines, as a way to fetch secrets from different mount paths.
+====
+
 == Programmatic access to the KV secret engine
 
 Sometimes secrets are retrieved from an arbitrary path that is known only at runtime through an application

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultKvSecretEngineV1AliasITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultKvSecretEngineV1AliasITCase.java
@@ -1,0 +1,36 @@
+package io.quarkus.vault;
+
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_VALUE;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultKvSecretEngineV1AliasITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-vault-secret-engine-mount-path-v1.properties", "application.properties"));
+
+    @ConfigProperty(name = "secret")
+    String secret;
+
+    @ConfigProperty(name = "myfoo.secret")
+    String myfoo_secret;
+
+    @Test
+    void configSource() {
+        Assertions.assertEquals(SECRET_VALUE, secret);
+        Assertions.assertEquals(SECRET_VALUE, myfoo_secret);
+    }
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultKvSecretEngineV2AliasITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultKvSecretEngineV2AliasITCase.java
@@ -1,0 +1,36 @@
+package io.quarkus.vault;
+
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_VALUE;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultKvSecretEngineV2AliasITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-vault-secret-engine-mount-path-v2.properties", "application.properties"));
+
+    @ConfigProperty(name = "secret")
+    String secret;
+
+    @ConfigProperty(name = "myfoo.secret")
+    String myfoo_secret;
+
+    @Test
+    void configSource() {
+        Assertions.assertEquals(SECRET_VALUE, secret);
+        Assertions.assertEquals(SECRET_VALUE, myfoo_secret);
+    }
+}

--- a/integration-tests/vault/src/test/resources/application-vault-secret-engine-mount-path-v1.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-secret-engine-mount-path-v1.properties
@@ -1,0 +1,10 @@
+quarkus.vault.url=https://localhost:8200
+quarkus.vault.authentication.userpass.username=bob
+quarkus.vault.authentication.userpass.password=sinclair
+
+quarkus.vault.kv-secret-engine."myengine1".version=1
+quarkus.vault.kv-secret-engine."myengine1".mount-path=secret-v1
+quarkus.vault.kv-secret-engine."myengine1".secret-config-kv-path=foo
+quarkus.vault.kv-secret-engine."myengine1".secret-config-kv-path."myfoo"=foo
+
+quarkus.tls.trust-all=true

--- a/integration-tests/vault/src/test/resources/application-vault-secret-engine-mount-path-v2.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-secret-engine-mount-path-v2.properties
@@ -1,0 +1,10 @@
+quarkus.vault.url=https://localhost:8200
+quarkus.vault.authentication.userpass.username=bob
+quarkus.vault.authentication.userpass.password=sinclair
+
+quarkus.vault.kv-secret-engine."myengine2".version=2
+quarkus.vault.kv-secret-engine."myengine2".mount-path=secret
+quarkus.vault.kv-secret-engine."myengine2".secret-config-kv-path=foo
+quarkus.vault.kv-secret-engine."myengine2".secret-config-kv-path."myfoo"=foo
+
+quarkus.tls.trust-all=true

--- a/runtime/src/main/java/io/quarkus/vault/VaultKVSecretReactiveEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultKVSecretReactiveEngine.java
@@ -18,16 +18,32 @@ public interface VaultKVSecretReactiveEngine {
      * Provides the values stored in the Vault kv secret engine at a particular path.
      * This is a shortcut to `readSecretJson(String)` when the secret value is a String, which is the common case.
      *
+     * @param alias the name of the kv engine mount path, or <default> for the default kv engine
      * @param path in Vault, without the kv engine mount path
      * @return list of key value pairs stored at 'path' in Vault
+     */
+    Uni<Map<String, String>> readSecret(String alias, String path);
+
+    /**
+     * read secret for the default kv engine mount path.
+     *
+     * @see VaultKVSecretReactiveEngine#readSecret(String, String)
      */
     Uni<Map<String, String>> readSecret(String path);
 
     /**
      * Provides the values stored in the Vault kv secret engine at a particular path.
      *
+     * @param alias the name of the kv engine mount path, or <default> for the default kv engine
      * @param path in Vault, without the kv engine mount path
      * @return list of key value pairs stored at 'path' in Vault
+     */
+    Uni<Map<String, Object>> readSecretJson(String alias, String path);
+
+    /**
+     * read secret as json for the default kv engine mount path.
+     *
+     * @see VaultKVSecretReactiveEngine#readSecretJson(String, String)
      */
     Uni<Map<String, Object>> readSecretJson(String path);
 
@@ -35,8 +51,16 @@ public interface VaultKVSecretReactiveEngine {
      * Writes the secret at the given path. If the path does not exist, the secret will
      * be created. If not the new secret will be merged with the existing one.
      *
+     * @param alias the name of the kv engine mount path, or <default> for the default kv engine
      * @param path in Vault, without the kv engine mount path
      * @param secret to write at path
+     */
+    Uni<Void> writeSecret(String alias, String path, Map<String, String> secret);
+
+    /**
+     * write secret for the default kv engine mount path.
+     *
+     * @see VaultKVSecretReactiveEngine#writeSecret(String, String, Map)
      */
     Uni<Void> writeSecret(String path, Map<String, String> secret);
 
@@ -44,16 +68,31 @@ public interface VaultKVSecretReactiveEngine {
      * Deletes the secret at the given path. It has no effect if no secret is currently
      * stored at path.
      *
+     * @param alias the name of the kv engine mount path, or <default> for the default kv engine
      * @param path to delete
+     */
+    Uni<Void> deleteSecret(String alias, String path);
+
+    /**
+     * delete secret for the default kv engine mount path.
+     *
+     * @see VaultKVSecretReactiveEngine#deleteSecret(String, String)
      */
     Uni<Void> deleteSecret(String path);
 
     /**
      * List all paths under the specified path.
      *
+     * @param alias the name of the kv engine mount path, or <default> for the default kv engine
      * @param path to list
      * @return list of subpaths
      */
-    Uni<List<String>> listSecrets(String path);
+    Uni<List<String>> listSecrets(String alias, String path);
 
+    /**
+     * List all paths under the specified path for the default kv engine mount path.
+     *
+     * @see VaultKVSecretReactiveEngine#listSecrets(String, String)
+     */
+    Uni<List<String>> listSecrets(String path);
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
@@ -1,22 +1,27 @@
 package io.quarkus.vault.runtime;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 
 import io.quarkus.vault.VaultKVSecretReactiveEngine;
 import io.quarkus.vault.client.VaultClient;
-import io.quarkus.vault.client.api.secrets.kv1.VaultSecretsKV1;
-import io.quarkus.vault.client.api.secrets.kv2.VaultSecretsKV2;
-import io.quarkus.vault.client.api.secrets.kv2.VaultSecretsKV2ReadSecretData;
+import io.quarkus.vault.client.api.common.VaultRequestFactory;
 import io.quarkus.vault.runtime.client.Private;
+import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
+import io.quarkus.vault.runtime.kv.KvV1;
+import io.quarkus.vault.runtime.kv.KvV2;
+import io.quarkus.vault.runtime.kv.VersionedKv;
 import io.smallrye.mutiny.Uni;
 
 @ApplicationScoped
 public class VaultKvManager implements VaultKVSecretReactiveEngine {
+
+    public static final String DEFAULT = "<default>";
 
     @Produces
     @Private
@@ -24,48 +29,82 @@ public class VaultKvManager implements VaultKVSecretReactiveEngine {
         return new VaultKvManager(vaultClient, vaultConfigHolder);
     }
 
-    private final VaultSecretsKV1 kv1;
-    private final VaultSecretsKV2 kv2;
-    private final boolean isV1;
+    private final Map<String, VersionedKv<? extends VaultRequestFactory>> engines = new HashMap<>();
 
     public VaultKvManager(VaultClient vaultClient, VaultConfigHolder vaultConfigHolder) {
-        this.kv1 = vaultClient.secrets().kv1(vaultConfigHolder.getVaultRuntimeConfig().kvSecretEngineMountPath());
-        this.kv2 = vaultClient.secrets().kv2(vaultConfigHolder.getVaultRuntimeConfig().kvSecretEngineMountPath());
-        this.isV1 = vaultConfigHolder.getVaultRuntimeConfig().kvSecretEngineVersion() == 1;
+
+        VaultRuntimeConfig config = vaultConfigHolder.getVaultRuntimeConfig();
+
+        // default engine
+        putEngine(DEFAULT, vaultClient, config.kvSecretEngineVersion(), config.kvSecretEngineMountPath());
+
+        // named engines
+        for (var entry : config.kvSecretEngineAlias().entrySet()) {
+            String alias = entry.getKey();
+            var engineConfig = entry.getValue();
+            putEngine(alias, vaultClient, engineConfig.version(), engineConfig.mountPath());
+        }
     }
 
-    private Map<String, String> convert(Map<String, Object> map) {
-        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> (String) entry.getValue()));
+    private void putEngine(String alias, VaultClient vaultClient, int version, String mountPath) {
+        if (version == 1) {
+            engines.put(alias, new KvV1(vaultClient.secrets().kv1(mountPath)));
+        } else {
+            engines.put(alias, new KvV2(vaultClient.secrets().kv2(mountPath)));
+        }
+    }
+
+    VersionedKv<? extends VaultRequestFactory> getEngine(String alias) {
+        return Objects.requireNonNull(engines.get(alias));
     }
 
     @Override
     public Uni<Map<String, String>> readSecret(String path) {
-        return readSecretJson(path).map(this::convert);
+        return readSecret(DEFAULT, path);
+    }
+
+    @Override
+    public Uni<Map<String, String>> readSecret(String alias, String path) {
+        return getEngine(alias).readSecret(path);
     }
 
     @Override
     public Uni<Map<String, Object>> readSecretJson(String path) {
-        return isV1 ? Uni.createFrom().completionStage(kv1.read(path))
-                : Uni.createFrom().completionStage(kv2.readSecret(path)).map(VaultSecretsKV2ReadSecretData::getData);
+        return readSecretJson(DEFAULT, path);
+    }
+
+    @Override
+    public Uni<Map<String, Object>> readSecretJson(String alias, String path) {
+        return getEngine(alias).readSecretJson(path);
     }
 
     @Override
     public Uni<Void> writeSecret(String path, Map<String, String> secret) {
-        var secretMap = secret.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> (Object) entry.getValue()));
-        return isV1 ? Uni.createFrom().completionStage(kv1.update(path, secretMap))
-                : Uni.createFrom().completionStage(kv2.updateSecret(path, null, secretMap)).map(r -> null);
+        return writeSecret(DEFAULT, path, secret);
+    }
+
+    @Override
+    public Uni<Void> writeSecret(String alias, String path, Map<String, String> secret) {
+        return getEngine(alias).writeSecret(path, secret);
     }
 
     @Override
     public Uni<Void> deleteSecret(String path) {
-        return isV1 ? Uni.createFrom().completionStage(kv1.delete(path))
-                : Uni.createFrom().completionStage(kv2.deleteSecret(path));
+        return deleteSecret(DEFAULT, path);
+    }
+
+    @Override
+    public Uni<Void> deleteSecret(String alias, String path) {
+        return getEngine(alias).deleteSecret(path);
     }
 
     @Override
     public Uni<List<String>> listSecrets(String path) {
-        return isV1 ? Uni.createFrom().completionStage(kv1.list(path))
-                : Uni.createFrom().completionStage(kv2.listSecrets(path));
+        return listSecrets(DEFAULT, path);
+    }
+
+    @Override
+    public Uni<List<String>> listSecrets(String alias, String path) {
+        return getEngine(alias).listSecrets(path);
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -44,6 +44,10 @@ public interface VaultRuntimeConfig {
     String DEFAULT_APPROLE_AUTH_MOUNT_PATH = "approle";
     String DEFAULT_USERPASS_AUTH_MOUNT_PATH = "userpass";
 
+    @WithName("kv-secret-engine")
+    @ConfigDocMapKey("alias")
+    Map<String, KvSecretEngineConfig> kvSecretEngineAlias();
+
     /**
      * Microprofile Config ordinal.
      * <p>
@@ -324,6 +328,7 @@ public interface VaultRuntimeConfig {
                 ", logConfidentialityLevel=" + logConfidentialityLevel() +
                 ", kvSecretEngineVersion=" + kvSecretEngineVersion() +
                 ", kvSecretEngineMountPath='" + kvSecretEngineMountPath() + '\'' +
+                ", additional named engines='" + kvSecretEngineAlias().size() + '\'' +
                 ", tlsSkipVerify=" + tls().skipVerify() +
                 ", tlsCaCert=" + tls().caCert() +
                 ", connectTimeout=" + connectTimeout() +
@@ -357,5 +362,33 @@ public interface VaultRuntimeConfig {
 
         @Override
         String toString();
+    }
+
+    @ConfigGroup
+    interface KvSecretEngineConfig {
+
+        /**
+         * mount path for the named kv secret engine.
+         */
+        @WithDefault(DEFAULT_KV_SECRET_ENGINE_MOUNT_PATH)
+        String mountPath();
+
+        /**
+         * paths to mount as MP config properties.
+         */
+        Optional<List<String>> secretConfigKvPath();
+
+        /**
+         * paths to mount as MP config properties. all properties will be prefixed with the key.
+         */
+        @WithName("secret-config-kv-path")
+        @ConfigDocMapKey("prefix")
+        Map<String, KvPathConfig> secretConfigKvPathPrefix();
+
+        /**
+         * version for the named kv secret engine.
+         */
+        @WithDefault(KV_SECRET_ENGINE_VERSION_V2)
+        int version();
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/kv/KvV1.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/kv/KvV1.java
@@ -1,0 +1,37 @@
+package io.quarkus.vault.runtime.kv;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.vault.client.api.secrets.kv1.VaultSecretsKV1;
+import io.quarkus.vault.client.api.secrets.kv1.VaultSecretsKV1RequestFactory;
+import io.smallrye.mutiny.Uni;
+
+public class KvV1 extends VersionedKv<VaultSecretsKV1RequestFactory> {
+
+    private final VaultSecretsKV1 kvv1;
+
+    public KvV1(VaultSecretsKV1 kvv1) {
+        this.kvv1 = kvv1;
+    }
+
+    @Override
+    public Uni<Map<String, Object>> readSecretJson(String path) {
+        return Uni.createFrom().completionStage(kvv1.read(path));
+    }
+
+    @Override
+    public Uni<Void> writeSecret(String path, Map<String, String> secret) {
+        return Uni.createFrom().completionStage(kvv1.update(path, asSecretMap(secret)));
+    }
+
+    @Override
+    public Uni<Void> deleteSecret(String path) {
+        return Uni.createFrom().completionStage(kvv1.delete(path));
+    }
+
+    @Override
+    public Uni<List<String>> listSecrets(String path) {
+        return Uni.createFrom().completionStage(kvv1.list(path));
+    }
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/kv/KvV2.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/kv/KvV2.java
@@ -1,0 +1,38 @@
+package io.quarkus.vault.runtime.kv;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.vault.client.api.secrets.kv2.VaultSecretsKV2;
+import io.quarkus.vault.client.api.secrets.kv2.VaultSecretsKV2ReadSecretData;
+import io.quarkus.vault.client.api.secrets.kv2.VaultSecretsKV2RequestFactory;
+import io.smallrye.mutiny.Uni;
+
+public class KvV2 extends VersionedKv<VaultSecretsKV2RequestFactory> {
+
+    private final VaultSecretsKV2 kvv2;
+
+    public KvV2(VaultSecretsKV2 kvv2) {
+        this.kvv2 = kvv2;
+    }
+
+    @Override
+    public Uni<Map<String, Object>> readSecretJson(String path) {
+        return Uni.createFrom().completionStage(kvv2.readSecret(path)).map(VaultSecretsKV2ReadSecretData::getData);
+    }
+
+    @Override
+    public Uni<Void> writeSecret(String path, Map<String, String> secret) {
+        return Uni.createFrom().completionStage(kvv2.updateSecret(path, null, asSecretMap(secret))).map(r -> null);
+    }
+
+    @Override
+    public Uni<Void> deleteSecret(String path) {
+        return Uni.createFrom().completionStage(kvv2.deleteSecret(path));
+    }
+
+    @Override
+    public Uni<List<String>> listSecrets(String path) {
+        return Uni.createFrom().completionStage(kvv2.listSecrets(path));
+    }
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/kv/VersionedKv.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/kv/VersionedKv.java
@@ -1,0 +1,31 @@
+package io.quarkus.vault.runtime.kv;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.quarkus.vault.client.api.common.VaultRequestFactory;
+import io.smallrye.mutiny.Uni;
+
+public abstract class VersionedKv<T extends VaultRequestFactory> {
+
+    public abstract Uni<Map<String, Object>> readSecretJson(String path);
+
+    public abstract Uni<Void> writeSecret(String path, Map<String, String> secret);
+
+    public abstract Uni<Void> deleteSecret(String path);
+
+    public abstract Uni<List<String>> listSecrets(String path);
+
+    public Uni<Map<String, String>> readSecret(String path) {
+        return readSecretJson(path).map(this::convert);
+    }
+
+    private Map<String, String> convert(Map<String, Object> map) {
+        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> (String) entry.getValue()));
+    }
+
+    protected Map<String, Object> asSecretMap(Map<String, String> secret) {
+        return secret.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> (Object) entry.getValue()));
+    }
+}


### PR DESCRIPTION
this bring support named kv secret engines with their mount path, version and `secret-config-kv-path`.
for instance for a `v1` engine:
```
quarkus.vault.kv-secret-engine."myengine1".version=1
quarkus.vault.kv-secret-engine."myengine1".mount-path=secret-v1

quarkus.vault.kv-secret-engine."myengine1".secret-config-kv-path=foo
# and/or
quarkus.vault.kv-secret-engine."myengine1".secret-config-kv-path."myfoo"=foo
```
and for `v2`:
```
quarkus.vault.kv-secret-engine."myengine2".version=2
quarkus.vault.kv-secret-engine."myengine2".mount-path=secret

quarkus.vault.kv-secret-engine."myengine2".secret-config-kv-path=foo
# and/or
quarkus.vault.kv-secret-engine."myengine2".secret-config-kv-path."myfoo"=foo
```

the default engine (with mount path `secret` and version 2) is still available, and can be used alongside the named engines.
for instance this configuration will bring in the configuration context both path `secret/bar` and `secret-v1/foo`:
```
quarkus.vault.kv-secret-engine.secret-config-kv-path=bar

quarkus.vault.kv-secret-engine."myengine1".mount-path=secret-v1
quarkus.vault.kv-secret-engine."myengine1".secret-config-kv-path=foo
```

this is an alternate proposition to https://github.com/quarkiverse/quarkus-vault/pull/381