### PR TITLE
Change type of cas from Boolean to Integer

### DIFF
--- a/client/src/main/specs/secrets/kv2.yaml
+++ b/client/src/main/specs/secrets/kv2.yaml
@@ -321,7 +321,7 @@ types:
 - name: UpdateSecretOptions
   properties:
   - name: cas
-    type: Boolean
+    type: Integer
 
 - name: VersionsParams
   properties:


### PR DESCRIPTION
cas is an integer parameter as per the Hashi Vault Docs. :

https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#cas

cas (int: <optional>) - This flag is required if cas_required is set to true on either the secret or the engine's config. If not set the write will be allowed. In order for a write to be successful, cas must be set to the current version of the secret. If set to 0 a write will only be allowed if the key doesn't exist as unset keys do not have any version information. Also remember that soft deletes do not remove any underlying version data from storage. In order to write to a soft deleted key, the cas parameter must match the key's current version.