### PR TITLE
Declare Vault provided capability

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -70,6 +70,11 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <version>${quarkus.version}</version>
+                <configuration>
+                    <capabilities>
+                        <provides>io.quarkiverse.vault</provides>
+                    </capabilities>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>compile</phase>


### PR DESCRIPTION
Declare Vault provided capability following this documentation https://quarkus.io/guides/capabilities#declaring-capabilities

It should allow for an extension using an optional dependency on quarkiverse vault to check vault usage using this kind of code in a deployment processor.

```java
    @BuildStep
    List<AdditionalBeanBuildItem> additionalBeans(final Capabilities capabilities) {
        final List<AdditionalBeanBuildItem> additionalBeanBuildItems = new ArrayList<>();
        if (capabilities.isPresent("io.quarkiverse.vault")) {
            additionalBeanBuildItems.add(AdditionalBeanBuildItem.builder()
                    .addBeanClasses(VaultPassphraseRepository.class)
                    .build());
        }
        return additionalBeanBuildItems;
    }
```
