### PR TITLE
Add AWS IAM Authentication

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -36,6 +36,17 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>
+        <!-- AWS IAM AUTH (optional): only needed when using the AWS IAM authentication method -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- TEST DEPS -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/client/src/main/java/io/quarkus/vault/client/VaultClient.java
+++ b/client/src/main/java/io/quarkus/vault/client/VaultClient.java
@@ -114,6 +114,10 @@ public class VaultClient implements VaultRequestExecutor {
             return tokenProvider(new VaultKubernetesTokenProvider(options).caching(options.cachingRenewGracePeriod));
         }
 
+        public Builder awsIam(VaultAwsIamAuthOptions options) {
+            return tokenProvider(new VaultAwsIamTokenProvider(options).caching(options.cachingRenewGracePeriod));
+        }
+
         public Builder tokenProvider(VaultTokenProvider tokenProvider) {
             this.tokenProvider = tokenProvider;
             return this;

--- a/client/src/main/java/io/quarkus/vault/client/auth/VaultAwsIamAuthOptions.java
+++ b/client/src/main/java/io/quarkus/vault/client/auth/VaultAwsIamAuthOptions.java
@@ -1,0 +1,106 @@
+package io.quarkus.vault.client.auth;
+
+import static io.quarkus.vault.client.api.VaultAuthAccessor.DEFAULT_AWS_MOUNT_PATH;
+import static io.quarkus.vault.client.auth.VaultCachingTokenProvider.DEFAULT_RENEW_GRACE_PERIOD;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+public class VaultAwsIamAuthOptions extends VaultAuthOptions {
+
+    public static final String DEFAULT_STS_URL = "https://sts.amazonaws.com";
+
+    public static class Builder {
+        private String mountPath = DEFAULT_AWS_MOUNT_PATH;
+        private String role;
+        private Region region;
+        private String stsUrl = DEFAULT_STS_URL;
+        private String vaultServerId;
+        private AwsCredentialsProvider credentialsProvider;
+        private Duration cachingRenewGracePeriod = DEFAULT_RENEW_GRACE_PERIOD;
+
+        public Builder mountPath(String mountPath) {
+            this.mountPath = mountPath;
+            return this;
+        }
+
+        public Builder role(String role) {
+            this.role = role;
+            return this;
+        }
+
+        public Builder region(Region region) {
+            this.region = region;
+            return this;
+        }
+
+        public Builder region(String region) {
+            this.region = region != null ? Region.of(region) : null;
+            return this;
+        }
+
+        public Builder stsUrl(String stsUrl) {
+            this.stsUrl = stsUrl;
+            return this;
+        }
+
+        public Builder vaultServerId(String vaultServerId) {
+            this.vaultServerId = vaultServerId;
+            return this;
+        }
+
+        public Builder credentialsProvider(AwsCredentialsProvider credentialsProvider) {
+            this.credentialsProvider = credentialsProvider;
+            return this;
+        }
+
+        public Builder staticCredentials(String accessKey, String secretKey) {
+            this.credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+            return this;
+        }
+
+        public Builder caching(Duration cachingRenewGracePeriod) {
+            this.cachingRenewGracePeriod = cachingRenewGracePeriod;
+            return this;
+        }
+
+        public Builder noCaching() {
+            this.cachingRenewGracePeriod = Duration.ZERO;
+            return this;
+        }
+
+        public VaultAwsIamAuthOptions build() {
+            return new VaultAwsIamAuthOptions(this);
+        }
+    }
+
+    public final String mountPath;
+    public final String role;
+    public final Region region;
+    public final String stsUrl;
+    public final Optional<String> vaultServerId;
+    public final AwsCredentialsProvider credentialsProvider;
+
+    private VaultAwsIamAuthOptions(Builder builder) {
+        super(builder.cachingRenewGracePeriod);
+        this.mountPath = Objects.requireNonNull(builder.mountPath);
+        this.role = Objects.requireNonNull(builder.role, "role is required for AWS IAM authentication");
+        this.region = Objects.requireNonNull(builder.region, "region is required for AWS IAM authentication");
+        this.stsUrl = Objects.requireNonNull(builder.stsUrl);
+        this.vaultServerId = Optional.ofNullable(builder.vaultServerId);
+        this.credentialsProvider = builder.credentialsProvider != null ? builder.credentialsProvider
+                : DefaultCredentialsProvider.create();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+}

--- a/client/src/main/java/io/quarkus/vault/client/auth/VaultAwsIamTokenProvider.java
+++ b/client/src/main/java/io/quarkus/vault/client/auth/VaultAwsIamTokenProvider.java
@@ -1,0 +1,123 @@
+package io.quarkus.vault.client.auth;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import io.quarkus.vault.client.api.auth.aws.VaultAuthAws;
+import io.quarkus.vault.client.common.VaultResponse;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * Authenticates against Vault's AWS auth method using the {@code iam} workflow: a
+ * {@code sts:GetCallerIdentity} request is signed with AWS SigV4 credentials and handed to Vault,
+ * which replays it against STS to verify the caller's identity.
+ *
+ * @see <a href="https://developer.hashicorp.com/vault/api-docs/auth/aws">Vault AWS auth method</a>
+ */
+public class VaultAwsIamTokenProvider implements VaultTokenProvider {
+
+    private static final String GET_CALLER_IDENTITY_REQUEST_BODY = "Action=GetCallerIdentity&Version=2011-06-15";
+    private static final String VAULT_AWS_IAM_SERVER_ID_HEADER = "X-Vault-AWS-IAM-Server-ID";
+
+    private final String mountPath;
+    private final String role;
+    private final Region region;
+    private final String stsUrl;
+    private final Optional<String> vaultServerId;
+    private final AwsCredentialsProvider credentialsProvider;
+
+    public VaultAwsIamTokenProvider(String mountPath, String role, Region region, String stsUrl,
+            Optional<String> vaultServerId, AwsCredentialsProvider credentialsProvider) {
+        this.mountPath = mountPath;
+        this.role = role;
+        this.region = region;
+        this.stsUrl = stsUrl;
+        this.vaultServerId = vaultServerId;
+        this.credentialsProvider = credentialsProvider;
+    }
+
+    public VaultAwsIamTokenProvider(VaultAwsIamAuthOptions options) {
+        this(options.mountPath, options.role, options.region, options.stsUrl, options.vaultServerId,
+                options.credentialsProvider);
+    }
+
+    @Override
+    public CompletionStage<VaultToken> apply(VaultAuthRequest authRequest) {
+        var executor = authRequest.getExecutor();
+
+        // Building/signing the request resolves AWS credentials, which may perform blocking network
+        // calls (IMDS, STS, ...), so keep it off the calling (event loop) thread.
+        return CompletableFuture.supplyAsync(this::buildSignedRequest)
+                .thenCompose(signedRequest -> {
+                    var requestUrl = base64(signedRequest.getUri().toString());
+                    var requestBody = base64(GET_CALLER_IDENTITY_REQUEST_BODY);
+                    var requestHeaders = base64(headersToJsonString(signedRequest.headers()));
+
+                    return executor.execute(
+                            VaultAuthAws.FACTORY.login(mountPath, role, SdkHttpMethod.POST.name(), requestUrl,
+                                    requestBody, requestHeaders));
+                })
+                .thenApply(VaultResponse::getResult)
+                .thenApply(res -> {
+                    var auth = res.getAuth();
+                    return VaultToken.from(auth.getClientToken(), auth.isRenewable(), auth.getLeaseDuration(),
+                            auth.getNumUses(), authRequest.getInstantSource());
+                });
+    }
+
+    private SdkHttpFullRequest buildSignedRequest() {
+        var credentials = credentialsProvider.resolveCredentials();
+        return signRequest(buildGetCallerIdentityRequest(), credentials);
+    }
+
+    private SdkHttpFullRequest buildGetCallerIdentityRequest() {
+        var builder = SdkHttpFullRequest.builder()
+                .method(SdkHttpMethod.POST)
+                .uri(URI.create(stsUrl))
+                .appendHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+                .appendHeader("Content-Length", String.valueOf(GET_CALLER_IDENTITY_REQUEST_BODY.length()))
+                .contentStreamProvider(() -> new ByteArrayInputStream(GET_CALLER_IDENTITY_REQUEST_BODY.getBytes(UTF_8)));
+
+        vaultServerId.ifPresent(serverId -> builder.appendHeader(VAULT_AWS_IAM_SERVER_ID_HEADER, serverId));
+
+        return builder.build();
+    }
+
+    private SdkHttpFullRequest signRequest(SdkHttpFullRequest request, AwsCredentials credentials) {
+        var params = Aws4SignerParams.builder()
+                .awsCredentials(credentials)
+                .signingName("sts")
+                .signingRegion(region)
+                .build();
+        return Aws4Signer.create().sign(request, params);
+    }
+
+    private static String base64(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(UTF_8));
+    }
+
+    private static String headersToJsonString(Map<String, List<String>> headers) {
+        return "{"
+                + headers.entrySet().stream()
+                        .map(entry -> "\"" + entry.getKey() + "\":["
+                                + entry.getValue().stream().map(value -> "\"" + value + "\"").collect(joining(","))
+                                + "]")
+                        .collect(joining(","))
+                + "}";
+    }
+}

--- a/client/src/main/specs/auth/aws.yaml
+++ b/client/src/main/specs/auth/aws.yaml
@@ -1,0 +1,27 @@
+name: Aws
+category: auth
+traceNameTag: aws
+basePath: auth
+
+operations:
+
+- name: login
+  method: POST
+  path: login
+  authenticated: false
+  bodyFrom: [role, iamHttpRequestMethod, iamRequestUrl, iamRequestBody, iamRequestHeaders]
+  parameters:
+  - name: role
+    type: String
+  - name: iamHttpRequestMethod
+    type: String
+  - name: iamRequestUrl
+    type: String
+  - name: iamRequestBody
+    type: String
+  - name: iamRequestHeaders
+    type: String
+  result:
+    kind: leased
+    unwrapAuth: true
+    auth: []

--- a/client/src/test/java/io/quarkus/vault/client/VaultAwsIamTokenProviderTest.java
+++ b/client/src/test/java/io/quarkus/vault/client/VaultAwsIamTokenProviderTest.java
@@ -1,0 +1,74 @@
+package io.quarkus.vault.client;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.InstantSource;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.vault.client.api.auth.aws.VaultAuthAwsLoginParams;
+import io.quarkus.vault.client.auth.VaultAuthRequest;
+import io.quarkus.vault.client.auth.VaultAwsIamAuthOptions;
+import io.quarkus.vault.client.auth.VaultAwsIamTokenProvider;
+import io.quarkus.vault.client.common.VaultRequest;
+import io.quarkus.vault.client.common.VaultRequestExecutor;
+import io.quarkus.vault.client.common.VaultResponse;
+
+class VaultAwsIamTokenProviderTest {
+
+    private static final String LOGIN_RESPONSE = "{" +
+            "\"request_id\":\"req\",\"lease_id\":\"\",\"renewable\":false,\"lease_duration\":0,\"data\":null," +
+            "\"auth\":{\"client_token\":\"vault-token\",\"renewable\":true,\"lease_duration\":3600,\"num_uses\":0," +
+            "\"policies\":[],\"metadata\":{}}}";
+
+    @Test
+    void buildsSignedGetCallerIdentityLoginRequest() throws Exception {
+        var captured = new AtomicReference<VaultRequest<?>>();
+        VaultRequestExecutor executor = new VaultRequestExecutor() {
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            @Override
+            public <T> CompletionStage<VaultResponse<T>> execute(VaultRequest<T> request) {
+                captured.set(request);
+                return CompletableFuture.completedStage(
+                        new VaultResponse(request, 200, List.of(), LOGIN_RESPONSE.getBytes(UTF_8)));
+            }
+        };
+
+        var options = VaultAwsIamAuthOptions.builder()
+                .role("my-role")
+                .region("us-east-1")
+                .vaultServerId("vault.example.com")
+                .staticCredentials("AKIAEXAMPLE", "secretkey")
+                .build();
+
+        var token = new VaultAwsIamTokenProvider(options)
+                .apply(VaultAuthRequest.of(executor, null, InstantSource.system()))
+                .toCompletableFuture().get();
+
+        assertThat(token.getClientToken()).isEqualTo("vault-token");
+
+        var params = (VaultAuthAwsLoginParams) captured.get().getBody().orElseThrow();
+        assertThat(params.getRole()).isEqualTo("my-role");
+        assertThat(params.getIamHttpRequestMethod()).isEqualTo("POST");
+        assertThat(decode(params.getIamRequestUrl())).isEqualTo("https://sts.amazonaws.com");
+        assertThat(decode(params.getIamRequestBody())).isEqualTo("Action=GetCallerIdentity&Version=2011-06-15");
+
+        var headers = decode(params.getIamRequestHeaders());
+        assertThat(headers)
+                .contains("\"Authorization\"")
+                .contains("AWS4-HMAC-SHA256")
+                .contains("Credential=AKIAEXAMPLE/")
+                .contains("/us-east-1/sts/aws4_request")
+                .contains("\"X-Vault-AWS-IAM-Server-ID\":[\"vault.example.com\"]");
+    }
+
+    private static String decode(String base64) {
+        return new String(Base64.getDecoder().decode(base64), UTF_8);
+    }
+}

--- a/docs/modules/ROOT/pages/vault-auth.adoc
+++ b/docs/modules/ROOT/pages/vault-auth.adoc
@@ -25,6 +25,8 @@ There are several Vault authentication methods supported in Quarkus today, namel
 * https://www.vaultproject.io/docs/auth/approle[AppRole]: authenticate with a role id and a secret id (which can
 be seen as a _Userpass_ for automated workflows - machines and services)
 * https://www.vaultproject.io/docs/auth/kubernetes[Kubernetes], which is applicable to workloads deployed into Kubernetes
+* https://developer.hashicorp.com/vault/docs/auth/aws[AWS IAM]: authenticate an AWS IAM principal by signing a
+`sts:GetCallerIdentity` request, which is applicable to workloads running on AWS (EC2, ECS, EKS, Lambda, …​)
 
 This guide aims at providing examples for each of those authentication methods.
 
@@ -470,3 +472,84 @@ curl http://localhost:30400/hello/private-key
 ----
 
 You should see `{private-key}`.
+
+== AWS IAM Authentication
+
+Vault's https://developer.hashicorp.com/vault/docs/auth/aws[AWS auth method] (in its `iam` flavor) lets a
+workload running on AWS authenticate using the AWS IAM credentials it already has, without provisioning any
+Vault-specific secret. The client builds a `sts:GetCallerIdentity` request, signs it with AWS SigV4, and sends
+the signed request to Vault, which replays it against STS to verify the caller's identity and maps the resolved
+IAM principal (ARN) to a Vault role.
+
+=== AWS SDK dependency
+
+Because it relies on the AWS SigV4 signer and credential resolution, this authentication method requires the AWS
+SDK, which is an *optional* dependency of the Vault extension. Applications using AWS IAM authentication must add
+it to their build:
+
+[source,xml,subs=attributes+]
+----
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>auth</artifactId>
+</dependency>
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>regions</artifactId>
+</dependency>
+<!-- Required unless only static credentials (aws-access-key/aws-secret-key) are used -->
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>url-connection-client</artifactId>
+</dependency>
+----
+
+The `url-connection-client` provides the HTTP client implementation the AWS SDK uses to resolve credentials
+from the default provider chain (EC2 instance metadata, ECS, STS web identity / IRSA, …​). It can be omitted
+when the application only relies on static credentials (`aws-access-key` / `aws-secret-key`); any other AWS SDK
+HTTP client (for example `apache-client` or `netty-nio-client`) can be substituted for it.
+
+NOTE: Applications that do *not* use AWS IAM authentication never need these dependencies, in JVM mode or in
+native mode. In a native image, the AWS IAM support is substituted away when the AWS SDK is absent from the
+classpath, so it does not take part in the closed-world analysis.
+
+=== Vault setup
+
+Enable the auth method and map an IAM principal ARN to a Vault role:
+
+[source,bash,subs=attributes+]
+----
+/ # vault auth enable aws
+/ # vault write auth/aws/role/vault-quickstart-role auth_type=iam \
+      bound_iam_principal_arn="arn:aws:iam::123456789012:role/my-app-role" \
+      policies=vault-quickstart-policy
+----
+
+=== Application configuration
+
+Selecting the `role` is what activates AWS IAM authentication:
+
+[source,properties,subs=attributes+]
+----
+quarkus.vault.url=http://localhost:8200
+quarkus.vault.authentication.aws-iam.role=vault-quickstart-role
+quarkus.vault.authentication.aws-iam.region=us-east-1
+----
+
+By default the AWS credentials are resolved through the standard AWS default credentials provider chain
+(environment variables, system properties, web identity token, EC2/ECS/EKS instance metadata, …​), so nothing
+else is usually required when running on AWS. Static credentials can be supplied explicitly for testing:
+
+[source,properties,subs=attributes+]
+----
+quarkus.vault.authentication.aws-iam.aws-access-key=AKIA...
+quarkus.vault.authentication.aws-iam.aws-secret-key=...
+----
+
+If the Vault AWS auth method is configured with an `iam_server_id_header_value` (recommended, to mitigate replay
+attacks), set the matching value so it is included in the signed `X-Vault-AWS-IAM-Server-ID` header:
+
+[source,properties,subs=attributes+]
+----
+quarkus.vault.authentication.aws-iam.vault-server-id=vault.example.com
+----

--- a/integration-tests/vault/pom.xml
+++ b/integration-tests/vault/pom.xml
@@ -43,6 +43,23 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
+        <!-- AWS IAM authentication (see VaultAwsIamITCase): the AWS SDK deps are optional in the
+             extension, so they must be provided explicitly by applications using AWS IAM auth. -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.quarkiverse.vault</groupId>
             <artifactId>quarkus-vault-deployment</artifactId>

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAwsIamITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAwsIamITCase.java
@@ -1,0 +1,59 @@
+package io.quarkus.vault;
+
+import static io.quarkus.vault.test.VaultTestExtension.APP_SECRET_PATH;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_KEY;
+import static io.quarkus.vault.test.VaultTestExtension.SECRET_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.vault.test.VaultTestLifecycleManager;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(VaultTestLifecycleManager.class)
+public class VaultAwsIamITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-vault-aws-iam.properties", "application.properties"));
+
+    @ConfigProperty(name = "quarkus.vault.authentication.aws-iam.role")
+    String role;
+
+    @ConfigProperty(name = "quarkus.vault.authentication.aws-iam.aws-access-key")
+    String key;
+
+    @Inject
+    VaultKVSecretEngine kvSecretEngine;
+
+    @Test
+    public void testRoleConfig() {
+        assertEquals("myawsiamrole", role);
+    }
+
+    @Test
+    public void testAwsAccessKeyConfig() {
+        assertNotNull(key);
+    }
+
+    @Test
+    public void testSuccessAuth() {
+        // reading a secret forces an AWS IAM login against Vault (signed sts:GetCallerIdentity replayed
+        // against LocalStack), so a successful read proves authentication works end-to-end.
+        Map<String, String> secrets = kvSecretEngine.readSecret(APP_SECRET_PATH);
+        assertEquals("{" + SECRET_KEY + "=" + SECRET_VALUE + "}", secrets.toString());
+    }
+
+}

--- a/integration-tests/vault/src/test/resources/application-vault-aws-iam.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-aws-iam.properties
@@ -1,0 +1,16 @@
+quarkus.vault.url=https://localhost:8200
+
+# aws-user access/secret keys provided by VaultTestLifecycleManager
+quarkus.vault.authentication.aws-iam.role=myawsiamrole
+quarkus.vault.authentication.aws-iam.region=us-east-1
+quarkus.vault.authentication.aws-iam.sts-url=http://mylocalstack:4566
+quarkus.vault.authentication.aws-iam.vault-server-id=vault.example.com
+quarkus.vault.authentication.aws-iam.aws-access-key=${vault-test.aws-user.access-key}
+quarkus.vault.authentication.aws-iam.aws-secret-key=${vault-test.aws-user.secret-key}
+
+quarkus.vault.tls.ca-cert=src/test/resources/vault-tls.crt
+
+quarkus.vault.log-confidentiality-level=low
+quarkus.vault.renew-grace-period=10
+
+quarkus.log.category."io.quarkus.vault".level=DEBUG

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <jandex.version>3.6.0</jandex.version>
     <assertj.version>3.27.7</assertj.version>
     <wiremock.version>3.13.2</wiremock.version>
+    <aws-sdk.version>2.42.7</aws-sdk.version>
     <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>
     <sundrio-maven-plugin.version>0.300.0</sundrio-maven-plugin.version>
   </properties>
@@ -44,6 +45,13 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>
         <version>${quarkus.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${aws-sdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -57,6 +57,35 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- GraalVM substitution annotations (build-time only), used to keep the optional AWS SDK
+             out of the native image closed-world analysis when it is not on the classpath. -->
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- AWS IAM AUTH (optional): applications using the AWS IAM authentication method must add
+             these AWS SDK dependencies (or an extension that brings them) to their own build. -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- HTTP client implementation used by the AWS SDK to resolve credentials from the default
+             provider chain (IMDS, ECS, STS web identity/IRSA). Discovered at runtime via ServiceLoader.
+             Not needed when only static credentials are configured. -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultAwsIamAuthConfigurator.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultAwsIamAuthConfigurator.java
@@ -1,0 +1,43 @@
+package io.quarkus.vault.runtime.client;
+
+import io.quarkus.vault.client.VaultClient;
+import io.quarkus.vault.client.VaultException;
+import io.quarkus.vault.client.auth.VaultAwsIamAuthOptions;
+import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
+
+/**
+ * Configures AWS IAM authentication on a {@link VaultClient.Builder}.
+ * <p>
+ * This is deliberately isolated in its own class, and exposes no AWS SDK types in its signature, so
+ * that it is the single point where the (optional) AWS SDK is referenced. When the AWS SDK is not on
+ * the classpath, a GraalVM substitution replaces {@link #configure} during native image builds, which
+ * keeps the AWS SDK out of the closed-world analysis for applications that do not use AWS IAM
+ * authentication.
+ *
+ * @see io.quarkus.vault.runtime.graal.Target_VaultAwsIamAuthConfigurator
+ */
+public final class VaultAwsIamAuthConfigurator {
+
+    private VaultAwsIamAuthConfigurator() {
+    }
+
+    public static void configure(VaultClient.Builder builder, VaultRuntimeConfig config) {
+
+        var awsIamConfig = config.authentication().awsIam();
+
+        var awsIamOptions = VaultAwsIamAuthOptions.builder()
+                .mountPath(awsIamConfig.authMountPath())
+                .role(awsIamConfig.role().orElseThrow())
+                .region(awsIamConfig.region().orElseThrow(
+                        () -> new VaultException("region is required for AWS IAM authentication")))
+                .stsUrl(awsIamConfig.stsUrl())
+                .caching(config.renewGracePeriod());
+        awsIamConfig.vaultServerId().ifPresent(awsIamOptions::vaultServerId);
+        if (awsIamConfig.awsAccessKey().isPresent() && awsIamConfig.awsSecretKey().isPresent()) {
+            awsIamOptions.staticCredentials(awsIamConfig.awsAccessKey().orElseThrow(),
+                    awsIamConfig.awsSecretKey().orElseThrow());
+        }
+
+        builder.awsIam(awsIamOptions.build());
+    }
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientProducer.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientProducer.java
@@ -146,6 +146,12 @@ public class VaultClientProducer {
                     builder.github(githubOptions.build());
                     break;
 
+                case AWS_IAM:
+                    // Isolated so that the optional AWS SDK is referenced from exactly one place,
+                    // which can be substituted away in native images when the SDK is absent.
+                    VaultAwsIamAuthConfigurator.configure(builder, config);
+                    break;
+
                 default:
                     throw new VaultException("Unsupported authentication type: " + config.getAuthenticationType());
             }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
@@ -52,6 +52,13 @@ public interface VaultAuthenticationConfig {
      */
     VaultGithubAuthenticationConfig github();
 
+    /**
+     * AWS IAM authentication method
+     * <p>
+     * See <a href="https://developer.hashicorp.com/vault/api-docs/auth/aws">AWS Auth Method</a>
+     */
+    VaultAwsIamAuthenticationConfig awsIam();
+
     default boolean isDirectClientToken() {
         return clientToken().isPresent() || clientTokenWrappingToken().isPresent();
     }
@@ -68,5 +75,9 @@ public interface VaultAuthenticationConfig {
 
     default boolean isGithub() {
         return github().token().isPresent() || github().tokenWrappingToken().isPresent();
+    }
+
+    default boolean isAwsIam() {
+        return awsIam().role().isPresent();
     }
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
@@ -42,6 +42,18 @@ public enum VaultAuthenticationType {
      * <p>
      * https://developer.hashicorp.com/vault/api-docs/auth/github
      */
-    GITHUB
+    GITHUB,
+
+    /**
+     * AWS IAM vault authentication
+     * <p>
+     * The aws auth method provides an automated mechanism to retrieve a Vault token for IAM principals.
+     * A special AWS request signed with AWS IAM credentials ({@code sts:GetCallerIdentity}) is used for
+     * authentication, so no Vault-specific secret needs to be provisioned to the client: the IAM
+     * credentials already available to AWS instances, Lambda functions, etc. are used to authenticate.
+     * <p>
+     * see https://developer.hashicorp.com/vault/api-docs/auth/aws
+     */
+    AWS_IAM
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAwsIamAuthenticationConfig.java
@@ -1,0 +1,56 @@
+package io.quarkus.vault.runtime.config;
+
+import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_AWS_IAM_AUTH_MOUNT_PATH;
+import static io.quarkus.vault.runtime.config.VaultRuntimeConfig.DEFAULT_AWS_IAM_STS_URL;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+@ConfigGroup
+public interface VaultAwsIamAuthenticationConfig {
+
+    /**
+     * AWS IAM authentication role that has been created in Vault to associate Vault policies with an
+     * AWS IAM principal (ARN). This property is required when selecting the AWS IAM authentication type.
+     */
+    Optional<String> role();
+
+    /**
+     * The AWS region used to sign the {@code sts:GetCallerIdentity} request. This property is required
+     * when selecting the AWS IAM authentication type.
+     */
+    Optional<String> region();
+
+    /**
+     * The URL of the AWS STS endpoint used to build the {@code GetCallerIdentity} request.
+     */
+    @WithDefault(DEFAULT_AWS_IAM_STS_URL)
+    String stsUrl();
+
+    /**
+     * The Vault server ID sent in the {@code X-Vault-AWS-IAM-Server-ID} header of the signed request,
+     * used by Vault to mitigate replay attacks. Must match the {@code iam_server_id_header_value}
+     * configured on the Vault AWS auth method.
+     */
+    Optional<String> vaultServerId();
+
+    /**
+     * The AWS access key ID used to sign the request. When both the access key and secret key are set,
+     * static credentials are used; otherwise the AWS default credentials provider chain is used.
+     */
+    Optional<String> awsAccessKey();
+
+    /**
+     * The AWS secret access key used to sign the request. When both the access key and secret key are
+     * set, static credentials are used; otherwise the AWS default credentials provider chain is used.
+     */
+    Optional<String> awsSecretKey();
+
+    /**
+     * Allows configuring the AWS IAM authentication mount path.
+     */
+    @WithDefault(DEFAULT_AWS_IAM_AUTH_MOUNT_PATH)
+    String authMountPath();
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -3,6 +3,7 @@ package io.quarkus.vault.runtime.config;
 import static io.quarkus.vault.client.logging.LogConfidentialityLevel.LOW;
 import static io.quarkus.vault.client.logging.LogConfidentialityLevel.MEDIUM;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.APPROLE;
+import static io.quarkus.vault.runtime.config.VaultAuthenticationType.AWS_IAM;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.GITHUB;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.KUBERNETES;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.USERPASS;
@@ -45,6 +46,8 @@ public interface VaultRuntimeConfig {
     String DEFAULT_APPROLE_AUTH_MOUNT_PATH = "approle";
     String DEFAULT_USERPASS_AUTH_MOUNT_PATH = "userpass";
     String DEFAULT_GITHUB_AUTH_MOUNT_PATH = "github";
+    String DEFAULT_AWS_IAM_AUTH_MOUNT_PATH = "aws";
+    String DEFAULT_AWS_IAM_STS_URL = "https://sts.amazonaws.com";
 
     @WithName("kv-secret-engine")
     @ConfigDocMapKey("alias")
@@ -299,6 +302,8 @@ public interface VaultRuntimeConfig {
             return APPROLE;
         } else if (authentication().isGithub()) {
             return GITHUB;
+        } else if (authentication().isAwsIam()) {
+            return AWS_IAM;
         } else {
             return null;
         }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/graal/AwsSdkAbsent.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/graal/AwsSdkAbsent.java
@@ -1,0 +1,21 @@
+package io.quarkus.vault.runtime.graal;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Detects, at native image build time, whether the (optional) AWS SDK is absent from the classpath.
+ */
+public class AwsSdkAbsent implements BooleanSupplier {
+
+    private static final String AWS_CREDENTIALS_PROVIDER = "software.amazon.awssdk.auth.credentials.AwsCredentialsProvider";
+
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName(AWS_CREDENTIALS_PROVIDER, false, Thread.currentThread().getContextClassLoader());
+            return false;
+        } catch (ClassNotFoundException e) {
+            return true;
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkus/vault/runtime/graal/Target_VaultAwsIamAuthConfigurator.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/graal/Target_VaultAwsIamAuthConfigurator.java
@@ -1,0 +1,30 @@
+package io.quarkus.vault.runtime.graal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.quarkus.vault.client.VaultClient;
+import io.quarkus.vault.client.VaultException;
+import io.quarkus.vault.runtime.client.VaultAwsIamAuthConfigurator;
+import io.quarkus.vault.runtime.config.VaultRuntimeConfig;
+
+/**
+ * Replaces {@link VaultAwsIamAuthConfigurator#configure} when the AWS SDK is not on the classpath.
+ * <p>
+ * The Vault client producer is always reachable, so without this substitution the native image
+ * closed-world analysis would follow the AWS IAM branch into the AWS SDK and fail to link for every
+ * application, including those that never use AWS IAM authentication. Substituting the method body
+ * removes the only reference to the AWS SDK; applications that do use AWS IAM authentication put the
+ * SDK on the classpath, the predicate is then false, and the real implementation is kept.
+ */
+@TargetClass(value = VaultAwsIamAuthConfigurator.class, onlyWith = AwsSdkAbsent.class)
+final class Target_VaultAwsIamAuthConfigurator {
+
+    @Substitute
+    public static void configure(VaultClient.Builder builder, VaultRuntimeConfig config) {
+        throw new VaultException("AWS IAM authentication requires the AWS SDK, which was not found on the classpath. " +
+                "Add the software.amazon.awssdk:auth and software.amazon.awssdk:regions dependencies " +
+                "(plus an HTTP client such as software.amazon.awssdk:url-connection-client when not using " +
+                "static credentials) to use quarkus.vault.authentication.aws-iam.");
+    }
+}

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>testcontainers-rabbitmq</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-localstack</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -41,8 +41,15 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.utility.DockerImageName;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 import io.quarkus.vault.VaultKVSecretEngine;
 import io.quarkus.vault.client.VaultClient;
@@ -72,6 +79,7 @@ public class VaultTestExtension {
     public static final String VAULT_AUTH_APPROLE = "myapprole";
     public static final String VAULT_AUTH_GITHUB_TOKEN = "github-test-token";
     public static final String GITHUB_TOKEN_TEST_PATH = "github-wrapping-test";
+    public static final String VAULT_AUTH_AWS_IAM_ROLE = "myawsiamrole";
     public static final String SECRET_PATH_V1 = "secret-v1";
     public static final String SECRET_PATH_V2 = "secret";
     public static final String LIST_PATH = "hello";
@@ -84,6 +92,8 @@ public class VaultTestExtension {
     static final String VAULT_POLICY = "mypolicy";
     static final String POSTGRESQL_HOST = "mypostgresdb";
     static final String RABBITMQ_HOST = "myrabbitmq";
+    static final String LOCALSTACK_HOST = "mylocalstack";
+    static final String LOCALSTACK_PORT = "4566";
     static final String VAULT_URL = (useTls() ? "https" : "http") + "://localhost:" + VAULT_PORT;
     public static final String SECRET_KEY = "secret";
     public static final String ENCRYPTION_KEY_NAME = "my-encryption-key";
@@ -102,6 +112,7 @@ public class VaultTestExtension {
     public static final String HOST_POSTGRES_TMP_CMD = "target/postgres_cmd";
     public static final String OUT_FILE = "/out";
     public static final String WRAPPING_TEST_PATH = "wrapping-test";
+    private static final String VAULT_AWS_SERVER_ID = "vault.example.com";
 
     public static final String TEST_POSTGRES_CONFIG = "vault-test.postgres.version";
     public static final String TEST_RABBITMQ_CONFIG = "vault-test.rabbitmq.version";
@@ -116,6 +127,7 @@ public class VaultTestExtension {
     public PostgreSQLContainer postgresContainer;
     public RabbitMQContainer rabbitMQContainer;
     public GithubMockServer githubMockServer;
+    public LocalStackContainer localStackContainer;
     public String rootToken = null;
     public String appRoleSecretId = null;
     public String appRoleRoleId = null;
@@ -125,6 +137,9 @@ public class VaultTestExtension {
     public String passwordKvv2WrappingToken = null;
     public String anotherPasswordKvv2WrappingToken = null;
     public String githubTokenKvv2WrappingToken = null;
+    public CreateAccessKeyResponse appAwsAccessKey = null;
+    private CreateAccessKeyResponse vaultAwsAccessKey = null;
+    private CreateUserResponse appAwsUser = null;
 
     private String db_default_ttl = "1m";
     private String db_max_ttl = "10m";
@@ -228,6 +243,14 @@ public class VaultTestExtension {
                 .withNetwork(network)
                 .withNetworkAliases(RABBITMQ_HOST);
 
+        Consumer<OutputFrame> localstackConsumer = outputFrame -> System.out.print("AWS >> " + outputFrame.getUtf8String());
+
+        localStackContainer = new LocalStackContainer(DockerImageName.parse("localstack/localstack:2.1"))
+                .withServices(LocalStackContainer.Service.STS, LocalStackContainer.Service.IAM)
+                .withLogConsumer(localstackConsumer)
+                .withNetwork(network)
+                .withNetworkAliases(LOCALSTACK_HOST);
+
         String configFile = useTls() ? "vault-config-tls.json" : "vault-config.json";
 
         String vaultImage = getVaultImage();
@@ -261,6 +284,9 @@ public class VaultTestExtension {
 
         rabbitMQContainer.start();
 
+        localStackContainer.start();
+        initLocalStack();
+
         Consumer<OutputFrame> consumer = outputFrame -> System.out.print("VAULT >> " + outputFrame.getUtf8String());
         vaultContainer.setLogConsumers(Arrays.asList(consumer));
         vaultContainer.start();
@@ -271,6 +297,32 @@ public class VaultTestExtension {
 
     private String getVaultImage() {
         return "hashicorp/vault:" + VaultVersions.VAULT_TEST_VERSION;
+    }
+
+    private void initLocalStack() throws IOException, InterruptedException {
+        ObjectMapper objectMapper = JsonMapper.builder()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+                .serializationInclusion(JsonInclude.Include.NON_NULL)
+                .build();
+
+        createLocalstackIamUser("vault-user", objectMapper);
+        vaultAwsAccessKey = createLocalstackUserAccessKey("vault-user", objectMapper);
+
+        appAwsUser = createLocalstackIamUser("app-user", objectMapper);
+        appAwsAccessKey = createLocalstackUserAccessKey("app-user", objectMapper);
+    }
+
+    private CreateUserResponse createLocalstackIamUser(String username, ObjectMapper objectMapper)
+            throws IOException, InterruptedException {
+        String outCreateUser = execLocalStack("awslocal", "iam", "create-user", "--user-name", username);
+        return objectMapper.readValue(outCreateUser, CreateUserResponse.class);
+    }
+
+    private CreateAccessKeyResponse createLocalstackUserAccessKey(String username, ObjectMapper objectMapper)
+            throws IOException, InterruptedException {
+        String outAccessKey = execLocalStack("awslocal", "iam", "create-access-key", "--user-name", username);
+        return objectMapper.readValue(outAccessKey, CreateAccessKeyResponse.class);
     }
 
     private void initVault() throws Exception {
@@ -331,6 +383,29 @@ public class VaultTestExtension {
         appRoleRoleId = vaultClient.auth().appRole().readRoleId(VAULT_AUTH_APPROLE).toCompletableFuture().get();
         log.info(
                 format("generated role_id=%s secret_id=%s for approle=%s", appRoleRoleId, appRoleSecretId, VAULT_AUTH_APPROLE));
+
+        // aws iam auth
+        execVault("vault auth enable aws");
+        execVault(format(
+                "vault write auth/aws/config/client secret_key=%s access_key=%s",
+                vaultAwsAccessKey.accessKey.secretAccessKey,
+                vaultAwsAccessKey.accessKey.accessKeyId));
+
+        execVault(format(
+                "vault write auth/aws/config/client iam_server_id_header_value=%s iam_endpoint=%s sts_endpoint=%s",
+                VAULT_AWS_SERVER_ID,
+                "http://" + LOCALSTACK_HOST + ":" + LOCALSTACK_PORT,
+                "http://" + LOCALSTACK_HOST + ":" + LOCALSTACK_PORT));
+
+        execVault("vault read auth/aws/config/client");
+
+        execVault(format(
+                "vault write auth/aws/role/%s auth_type=iam bound_iam_principal_arn=%s policies=%s",
+                VAULT_AUTH_AWS_IAM_ROLE,
+                appAwsUser.user.arn,
+                VAULT_POLICY));
+
+        execVault("vault read auth/aws/role/" + VAULT_AUTH_AWS_IAM_ROLE);
 
         // policy
         String policyContent = readResourceContent("vault.policy");
@@ -534,6 +609,10 @@ public class VaultTestExtension {
         return exec(vaultContainer, command, cmd, HOST_VAULT_TMP_CMD + OUT_FILE);
     }
 
+    private String execLocalStack(final String... command) throws IOException, InterruptedException {
+        return exec(localStackContainer, command).getStdout();
+    }
+
     private String exec(GenericContainer container, String command, String[] cmd, String outFile)
             throws IOException, InterruptedException {
         exec(container, cmd);
@@ -576,7 +655,27 @@ public class VaultTestExtension {
         if (githubMockServer != null) {
             githubMockServer.close();
         }
+        if (localStackContainer != null && localStackContainer.isRunning()) {
+            localStackContainer.stop();
+        }
 
         // VaultManager.getInstance().reset();
+    }
+
+    static class CreateAccessKeyResponse {
+        public AwsAccessKey accessKey;
+    }
+
+    static class AwsAccessKey {
+        public String accessKeyId;
+        public String secretAccessKey;
+    }
+
+    static class CreateUserResponse {
+        public AwsUser user;
+    }
+
+    static class AwsUser {
+        public String arn;
     }
 }

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestLifecycleManager.java
@@ -44,6 +44,9 @@ public class VaultTestLifecycleManager implements QuarkusTestResourceLifecycleMa
         sysprops.put("vault-test.another-password-kv-v2-wrapping-token", vaultTestExtension.anotherPasswordKvv2WrappingToken);
         sysprops.put("vault-test.github-token-kv-v2-wrapping-token", vaultTestExtension.githubTokenKvv2WrappingToken);
 
+        sysprops.put("vault-test.aws-user.access-key", vaultTestExtension.appAwsAccessKey.accessKey.accessKeyId);
+        sysprops.put("vault-test.aws-user.secret-key", vaultTestExtension.appAwsAccessKey.accessKey.secretAccessKey);
+
         log.info("using system properties " + sysprops);
 
         return sysprops;


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-vault/issues/39

from original https://github.com/quarkiverse/quarkus-vault/pull/143 by @yuriytkach
re-implemented on top of `main`, using the new generated vault client
simplified dependencies: using `auth`, `regions` and `url-connection-client` instead of the original heavy `sts` dependency.
migrated to `testcontainers-localstack` 2.x
cc @kdubb 