### PR TITLE
Document that Dev Services init-commands must omit the vault prefix

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
@@ -195,7 +195,11 @@ a|icon:lock[title=Fixed at build time] [[quarkus-vault_quarkus-vault-devservices
 
 [.description]
 --
-Custom container initialization commands
+Custom container initialization commands.
+
+Each command is executed inside the started container with the Vault CLI, once the server is up and running. Since commands are passed directly to the `vault` executable, the `vault` prefix must be omitted. For instance, to create a Transit key, use `write -f transit/keys/my-key` instead of `vault write -f transit/keys/my-key`.
+
+Commands are executed in the order they are defined, and are authenticated with the root token.
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_DEVSERVICES_INIT_COMMANDS+++[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -578,6 +578,34 @@ Enable the **PKI Secret Engine** at `pki/` using:
 quarkus.vault.devservices.pki-enabled=true
 ----
 
+=== Custom Provisioning with Init Commands
+
+For any provisioning beyond enabling the Transit and PKI secret engines, you can provide a list of
+_init commands_ that will be executed with the Vault CLI inside the container, once the server is up and running.
+
+Since the commands are passed directly to the `vault` executable running in the container, the `vault` prefix
+must be omitted. For instance, to create a Transit key named `my-key`, use `write -f transit/keys/my-key`
+instead of `vault write -f transit/keys/my-key`:
+
+[source,properties]
+----
+quarkus.vault.devservices.transit-enabled=true
+quarkus.vault.devservices.init-commands=write -f transit/keys/my-key
+----
+
+Commands are executed in the order they are defined, and are authenticated with the root token, e.g.:
+
+[source,properties]
+----
+quarkus.vault.devservices.init-commands[0]=secrets enable -path=apps kv-v2
+quarkus.vault.devservices.init-commands[1]=kv put apps/my-app foo=bar
+----
+
+NOTE: If a command fails, the remaining commands are skipped and an error is logged, but the container still starts.
+Since Dev Services collapses startup log output, the error may be easy to miss.
+To troubleshoot init commands, you can execute them manually against the running container with
+`docker exec -it <container-id> vault <command>`.
+
 == Conclusion
 
 As a general matter, you should consider reading the extensive https://www.vaultproject.io/docs/[Vault documentation]

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/DevServicesConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/DevServicesConfig.java
@@ -71,7 +71,14 @@ public interface DevServicesConfig {
     boolean pkiEnabled();
 
     /**
-     * Custom container initialization commands
+     * Custom container initialization commands.
+     * <p>
+     * Each command is executed inside the started container with the Vault CLI, once the server
+     * is up and running. Since commands are passed directly to the {@code vault} executable,
+     * the {@code vault} prefix must be omitted. For instance, to create a Transit key,
+     * use {@code write -f transit/keys/my-key} instead of {@code vault write -f transit/keys/my-key}.
+     * <p>
+     * Commands are executed in the order they are defined, and are authenticated with the root token.
      */
     Optional<List<String>> initCommands();
 


### PR DESCRIPTION
Improves the documentation of `quarkus.vault.devservices.init-commands`, as requested in #397 (see also discussion #93).

Init commands are passed directly to the `vault` CLI inside the Dev Services container, so commands written as `vault write -f transit/keys/my-key` silently fail. This was the root cause in #397 and #93, and nothing in the docs mentioned it.

Changes:
- Expanded the `initCommands()` javadoc (source of the generated config reference) to state that the `vault` prefix must be omitted, with an example, and that commands run in order with the root token.
- Updated the generated config reference include to match.
- Added a "Custom Provisioning with Init Commands" section to the Dev Services chapter of the guide, with a Transit key example, a multi-command example, and a note on failure behavior (remaining commands skipped, error logged but hidden by collapsed Dev Services logging, `docker exec` troubleshooting tip).

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)