### PR TITLE
Add support for Vault Agent Auto-Auth

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
@@ -691,6 +691,25 @@ h|[[quarkus-vault_quarkus-vault-authentication-authentication]]link:#quarkus-vau
 h|Type
 h|Default
 
+a| [[quarkus-vault_quarkus-vault-authentication-none]]`link:#quarkus-vault_quarkus-vault-authentication-none[quarkus.vault.authentication.none]`
+
+
+[.description]
+--
+Disable authentication: no client token will be sent to Vault. This is useful when the Vault url points to a Vault Agent with Auto-Auth enabled, which authenticates on behalf of the application and injects the Vault token into proxied requests. This property is exclusive with all other authentication settings.
+
+See link:https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth[Vault Agent Auto-Auth]
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_AUTHENTICATION_NONE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_VAULT_AUTHENTICATION_NONE+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`false`
+
+
 a| [[quarkus-vault_quarkus-vault-authentication-client-token]]`link:#quarkus-vault_quarkus-vault-authentication-client-token[quarkus.vault.authentication.client-token]`
 
 

--- a/docs/modules/ROOT/pages/vault-auth.adoc
+++ b/docs/modules/ROOT/pages/vault-auth.adoc
@@ -28,6 +28,10 @@ be seen as a _Userpass_ for automated workflows - machines and services)
 * https://developer.hashicorp.com/vault/docs/auth/aws[AWS IAM]: authenticate an AWS IAM principal by signing a
 `sts:GetCallerIdentity` request, which is applicable to workloads running on AWS (EC2, ECS, EKS, Lambda, …​)
 
+Alternatively, authentication can be disabled entirely when the application talks to Vault through a
+https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth[Vault Agent with Auto-Auth enabled],
+which authenticates on behalf of the application. See <<vault-agent-auto-auth>>.
+
 This guide aims at providing examples for each of those authentication methods.
 
 == Prerequisites
@@ -552,4 +556,49 @@ attacks), set the matching value so it is included in the signed `X-Vault-AWS-IA
 [source,properties,subs=attributes+]
 ----
 quarkus.vault.authentication.aws-iam.vault-server-id=vault.example.com
+----
+
+[[vault-agent-auto-auth]]
+== Vault Agent Auto-Auth
+
+https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent[Vault Agent] is a client daemon, usually deployed
+as a sidecar next to the application, that can take over authentication through its
+https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth[Auto-Auth] feature. When the agent's listener
+is used as a proxy to the Vault server, the agent authenticates on behalf of the application and injects the Vault
+token into proxied requests itself. In that situation the application must not send any `X-Vault-Token` header.
+
+To support this deployment model, point the Vault url at the agent's listener and disable authentication explicitly:
+
+[source, properties]
+----
+# address of the Vault Agent listener, e.g. as a sidecar on localhost
+quarkus.vault.url=http://localhost:8100
+quarkus.vault.authentication.none=true
+----
+
+With `quarkus.vault.authentication.none=true` the extension skips the login step and sends all requests without
+a client token, letting the agent add it. This property is exclusive with all other authentication settings
+(e.g. `client-token`, `userpass`, `approle`, `kubernetes`, `github` or `aws-iam`); combining them results in an error when the
+Vault client gets created.
+
+An example agent configuration using the Kubernetes auth method and requiring token injection looks like:
+
+[source, hcl]
+----
+auto_auth {
+  method "kubernetes" {
+    config = {
+      role = "myapp"
+    }
+  }
+}
+
+listener "tcp" {
+  address = "127.0.0.1:8100"
+  tls_disable = true
+}
+
+api_proxy {
+  use_auto_auth_token = "force"
+}
 ----

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAgentAutoAuthITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAgentAutoAuthITCase.java
@@ -1,0 +1,31 @@
+package io.quarkus.vault;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+@QuarkusTestResource(WiremockVaultAgent.class)
+public class VaultAgentAutoAuthITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-vault-agent.properties", "application.properties"));
+
+    @Inject
+    VaultKVSecretEngine kvSecretEngine;
+
+    @Test
+    public void secretReadWithoutToken() {
+        assertEquals("{hello=world}", kvSecretEngine.readSecret("foo").toString());
+    }
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAuthenticationNoneConflictITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultAuthenticationNoneConflictITCase.java
@@ -1,0 +1,30 @@
+package io.quarkus.vault;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+@DisabledOnOs(OS.WINDOWS) // https://github.com/quarkusio/quarkus/issues/3796
+public class VaultAuthenticationNoneConflictITCase {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot((jar) -> jar
+                    .addAsResource("application-vault-agent-conflict.properties", "application.properties"));
+
+    @Inject
+    VaultKVSecretEngine kvSecretEngine;
+
+    @Test
+    public void conflictingAuthenticationRejected() {
+        assertThatThrownBy(() -> kvSecretEngine.readSecret("foo"))
+                .hasMessageContaining("'quarkus.vault.authentication.none' is exclusive");
+    }
+}

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/WiremockVaultAgent.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/WiremockVaultAgent.java
@@ -1,0 +1,47 @@
+package io.quarkus.vault;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+/**
+ * Simulates a Vault Agent listener with auto-auth enabled: the agent authenticates on behalf of the application
+ * and injects the Vault token into proxied requests itself, so requests coming from the application must not
+ * carry any X-Vault-Token header. The stub only matches requests where the header is absent.
+ */
+public class WiremockVaultAgent implements QuarkusTestResourceLifecycleManager {
+
+    private WireMockServer server;
+
+    @Override
+    public Map<String, String> start() {
+
+        server = new WireMockServer(wireMockConfig().dynamicPort());
+        server.start();
+
+        server.stubFor(get(urlEqualTo("/v1/secret/foo"))
+                .withHeader("X-Vault-Token", absent())
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                                "{\"request_id\":\"bf5245f4-f194-2b13-80b7-6cad145b8135\",\"lease_id\":\"\",\"renewable\":false,\"lease_duration\":2764800,\"wrap_info\":null,\"warnings\":null,\"auth\":null,"
+                                        + "\"data\":{\"hello\":\"world\"}}")));
+
+        return Map.of("vault-agent-test.url", "http://localhost:" + server.port());
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+}

--- a/integration-tests/vault/src/test/resources/application-vault-agent-conflict.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-agent-conflict.properties
@@ -1,0 +1,5 @@
+# invalid configuration: authentication.none is exclusive with any other authentication method
+# no request is ever sent, the vault client fails at creation time
+quarkus.vault.url=http://localhost:8200
+quarkus.vault.authentication.none=true
+quarkus.vault.authentication.client-token=123

--- a/integration-tests/vault/src/test/resources/application-vault-agent.properties
+++ b/integration-tests/vault/src/test/resources/application-vault-agent.properties
@@ -1,0 +1,6 @@
+# vault-agent-test.url provided by WiremockVaultAgent (simulating a Vault Agent with auto-auth enabled)
+quarkus.vault.url=${vault-agent-test.url}
+quarkus.vault.authentication.none=true
+quarkus.vault.kv-secret-engine-version=1
+
+quarkus.log.category."io.quarkus.vault".level=DEBUG

--- a/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientProducer.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/client/VaultClientProducer.java
@@ -72,7 +72,18 @@ public class VaultClientProducer {
 
         var authConfig = config.authentication();
 
-        if (authConfig.isDirectClientToken()) {
+        if (authConfig.none()) {
+
+            if (authConfig.isDirectClientToken() || authConfig.isAppRole() || authConfig.isUserpass()
+                    || authConfig.isGithub() || authConfig.isAwsIam()
+                    || authConfig.kubernetes().role().isPresent()) {
+                throw new VaultException("'quarkus.vault.authentication.none' is exclusive with all other " +
+                        "authentication properties; remove the other authentication settings or set 'none' to false");
+            }
+
+            // no token provider: requests are sent without a token, e.g. through a Vault Agent with auto-auth enabled
+
+        } else if (authConfig.isDirectClientToken()) {
 
             if (authConfig.clientTokenWrappingToken().isPresent()) {
                 builder.clientToken(VaultStaticClientTokenAuthOptions.builder()
@@ -84,7 +95,13 @@ public class VaultClientProducer {
 
         } else {
 
-            switch (config.getAuthenticationType()) {
+            var authenticationType = config.getAuthenticationType();
+            if (authenticationType == null) {
+                throw new VaultException("no vault authentication configured; if this is intentional, e.g. when " +
+                        "using a Vault Agent with auto-auth enabled, set 'quarkus.vault.authentication.none' to true");
+            }
+
+            switch (authenticationType) {
 
                 case KUBERNETES:
                     var k8sConfig = authConfig.kubernetes();

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationConfig.java
@@ -3,9 +3,20 @@ package io.quarkus.vault.runtime.config;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
 
 @ConfigGroup
 public interface VaultAuthenticationConfig {
+
+    /**
+     * Disable authentication: no client token will be sent to Vault. This is useful when the Vault url points to
+     * a Vault Agent with Auto-Auth enabled, which authenticates on behalf of the application and injects the Vault
+     * token into proxied requests. This property is exclusive with all other authentication settings.
+     * <p>
+     * See <a href="https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth">Vault Agent Auto-Auth</a>
+     */
+    @WithDefault("false")
+    boolean none();
 
     /**
      * Vault token, bypassing Vault authentication (kubernetes, userpass or approle). This is useful in development

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultAuthenticationType.java
@@ -54,6 +54,17 @@ public enum VaultAuthenticationType {
      * <p>
      * see https://developer.hashicorp.com/vault/api-docs/auth/aws
      */
-    AWS_IAM
+    AWS_IAM,
+
+    /**
+     * No authentication
+     * <p>
+     * Requests are sent to Vault without any client token. This is useful when the configured Vault url points
+     * to a Vault Agent configured with Auto-Auth, which authenticates on behalf of the application and injects
+     * the Vault token into proxied requests.
+     * <p>
+     * https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth
+     */
+    NONE
 
 }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/VaultRuntimeConfig.java
@@ -6,6 +6,7 @@ import static io.quarkus.vault.runtime.config.VaultAuthenticationType.APPROLE;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.AWS_IAM;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.GITHUB;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.KUBERNETES;
+import static io.quarkus.vault.runtime.config.VaultAuthenticationType.NONE;
 import static io.quarkus.vault.runtime.config.VaultAuthenticationType.USERPASS;
 
 import java.net.URL;
@@ -294,7 +295,9 @@ public interface VaultRuntimeConfig {
     Map<String, String> health();
 
     default VaultAuthenticationType getAuthenticationType() {
-        if (authentication().kubernetes().role().isPresent()) {
+        if (authentication().none()) {
+            return NONE;
+        } else if (authentication().kubernetes().role().isPresent()) {
             return KUBERNETES;
         } else if (authentication().isUserpass()) {
             return USERPASS;


### PR DESCRIPTION
Fixes #162

## What

Introduces `quarkus.vault.authentication.none`, an explicit opt-in that makes the extension send requests to Vault without any `X-Vault-Token` header. This allows pointing `quarkus.vault.url` at a [Vault Agent](https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent) listener with [Auto-Auth](https://developer.hashicorp.com/vault/docs/agent-and-proxy/autoauth) enabled: the agent authenticates on behalf of the application and injects the Vault token into proxied requests itself.

```properties
quarkus.vault.url=http://localhost:8100
quarkus.vault.authentication.none=true
```

## How

The low-level client already supports token-less requests when no token provider is set, so the change is confined to the extension layer:

- `VaultAuthenticationConfig`: new `none()` property (default `false`).
- `VaultAuthenticationType`: new `NONE` constant, returned by `VaultRuntimeConfig#getAuthenticationType()` when the flag is set.
- `VaultClientProducer`: when `none` is set, no token provider is installed; combining it with any other authentication settings fails with a descriptive error. A fully unconfigured authentication now also fails with a clear message (previously a `NullPointerException` from switching on a null authentication type).

An explicit flag was preferred over treating "no auth configured" as auto-auth mode, so that a typo'd authentication config keeps producing a startup error instead of silently sending unauthenticated requests.

## Testing

- `VaultAgentAutoAuthITCase` + `WiremockVaultAgent`: WireMock simulates the agent; the stub only matches requests where the `X-Vault-Token` header is **absent**, so any leaked token fails the test. The app reads a KV secret through the simulated agent.
- `VaultAuthenticationNoneConflictITCase`: asserts the error when `none` is combined with `client-token`.
- Full `integration-tests/vault` suite passes locally (the only errors are a pre-existing `VerifyError` in `VaultTestExtension.execLocalStack`, unrelated to this change).

## Docs

- New "Vault Agent Auto-Auth" section in `vault-auth.adoc` with a sample agent HCL configuration.
- Added the property to the generated config reference (`includes/quarkus-vault.adoc`) by hand, matching the generated format — note that `docs/pom.xml` still copies from the legacy `../target/asciidoc/generated/config/` path, which current Quarkus versions no longer produce, so local regeneration is a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
