### PR TITLE
Add support for destroy in Key-Value engine

### DIFF
--- a/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/VaultKv1ITCase.java
+++ b/integration-tests/vault-agroal/src/test/java/io/quarkus/vault/VaultKv1ITCase.java
@@ -1,10 +1,13 @@
 package io.quarkus.vault;
 
+import java.util.List;
+
 import jakarta.inject.Inject;
 
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -33,5 +36,11 @@ public class VaultKv1ITCase {
     @Test
     public void crudSecretV1() {
         VaultTestExtension.assertCrudSecret(kvSecretEngine);
+    }
+
+    @Test
+    public void destroySecretV1NotSupported() {
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> kvSecretEngine.destroySecret(CRUD_PATH, List.of(1)));
     }
 }

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -149,6 +149,11 @@ public class VaultITCase {
         VaultTestExtension.assertCrudSecret(kvSecretEngine);
     }
 
+    @Test
+    public void destroySecret() throws Exception {
+        VaultTestExtension.assertDestroySecret(kvSecretEngine);
+    }
+
     static class WrapExample {
         public String foo = "bar";
         public String zip = "zap";

--- a/runtime/src/main/java/io/quarkus/vault/VaultKVSecretEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultKVSecretEngine.java
@@ -68,6 +68,18 @@ public class VaultKVSecretEngine {
     }
 
     /**
+     * Permanently deletes the specified secret versions at the given path. Destroyed versions cannot
+     * be undeleted. This operation is supported by kv version 2 secret engines only, and throws an
+     * {@link UnsupportedOperationException} for a kv version 1 secret engine.
+     *
+     * @param path in Vault, without the kv engine mount path
+     * @param versions the secret versions to destroy
+     */
+    public void destroySecret(String path, List<Integer> versions) {
+        engine.destroySecret(path, versions).await().indefinitely();
+    }
+
+    /**
      * List all paths under the specified path.
      *
      * @param path to list

--- a/runtime/src/main/java/io/quarkus/vault/VaultKVSecretReactiveEngine.java
+++ b/runtime/src/main/java/io/quarkus/vault/VaultKVSecretReactiveEngine.java
@@ -81,6 +81,24 @@ public interface VaultKVSecretReactiveEngine {
     Uni<Void> deleteSecret(String path);
 
     /**
+     * Permanently deletes the specified secret versions at the given path. Destroyed versions cannot
+     * be undeleted. This operation is supported by kv version 2 secret engines only; the returned
+     * {@link Uni} fails with an {@link UnsupportedOperationException} for a kv version 1 secret engine.
+     *
+     * @param alias the name of the kv engine mount path, or <default> for the default kv engine
+     * @param path in Vault, without the kv engine mount path
+     * @param versions the secret versions to destroy
+     */
+    Uni<Void> destroySecret(String alias, String path, List<Integer> versions);
+
+    /**
+     * destroy secret versions for the default kv engine mount path.
+     *
+     * @see VaultKVSecretReactiveEngine#destroySecret(String, String, List)
+     */
+    Uni<Void> destroySecret(String path, List<Integer> versions);
+
+    /**
      * List all paths under the specified path.
      *
      * @param alias the name of the kv engine mount path, or <default> for the default kv engine

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultKvManager.java
@@ -99,6 +99,16 @@ public class VaultKvManager implements VaultKVSecretReactiveEngine {
     }
 
     @Override
+    public Uni<Void> destroySecret(String path, List<Integer> versions) {
+        return destroySecret(DEFAULT, path, versions);
+    }
+
+    @Override
+    public Uni<Void> destroySecret(String alias, String path, List<Integer> versions) {
+        return getEngine(alias).destroySecret(path, versions);
+    }
+
+    @Override
     public Uni<List<String>> listSecrets(String path) {
         return listSecrets(DEFAULT, path);
     }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/kv/KvV1.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/kv/KvV1.java
@@ -31,6 +31,12 @@ public class KvV1 extends VersionedKv<VaultSecretsKV1RequestFactory> {
     }
 
     @Override
+    public Uni<Void> destroySecret(String path, List<Integer> versions) {
+        return Uni.createFrom()
+                .failure(new UnsupportedOperationException("destroy secret is not supported by the kv v1 secret engine"));
+    }
+
+    @Override
     public Uni<List<String>> listSecrets(String path) {
         return Uni.createFrom().completionStage(kvv1.list(path));
     }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/kv/KvV2.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/kv/KvV2.java
@@ -32,6 +32,11 @@ public class KvV2 extends VersionedKv<VaultSecretsKV2RequestFactory> {
     }
 
     @Override
+    public Uni<Void> destroySecret(String path, List<Integer> versions) {
+        return Uni.createFrom().completionStage(kvv2.destroySecretVersions(path, versions));
+    }
+
+    @Override
     public Uni<List<String>> listSecrets(String path) {
         return Uni.createFrom().completionStage(kvv2.listSecrets(path));
     }

--- a/runtime/src/main/java/io/quarkus/vault/runtime/kv/VersionedKv.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/kv/VersionedKv.java
@@ -15,6 +15,8 @@ public abstract class VersionedKv<T extends VaultRequestFactory> {
 
     public abstract Uni<Void> deleteSecret(String path);
 
+    public abstract Uni<Void> destroySecret(String path, List<Integer> versions);
+
     public abstract Uni<List<String>> listSecrets(String path);
 
     public Uni<Map<String, String>> readSecret(String path) {

--- a/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
+++ b/test-framework/src/main/java/io/quarkus/vault/test/VaultTestExtension.java
@@ -23,6 +23,7 @@ import java.sql.Statement;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -177,6 +178,27 @@ public class VaultTestExtension {
         assertEquals("{first=un, second=two, third=tres}", readSecretAsString(kvSecretEngine, CRUD_PATH));
 
         assertDeleteSecret(kvSecretEngine);
+    }
+
+    public static void assertDestroySecret(VaultKVSecretEngine kvSecretEngine) {
+
+        String path = "crud-destroy";
+
+        kvSecretEngine.writeSecret(path, Map.of("first", "one")); // version 1
+        kvSecretEngine.writeSecret(path, Map.of("first", "two")); // version 2
+
+        // destroying a non current version does not impact the current version
+        kvSecretEngine.destroySecret(path, List.of(1));
+        assertEquals("{first=two}", readSecretAsString(kvSecretEngine, path));
+
+        // destroying the current version makes the secret unavailable
+        kvSecretEngine.destroySecret(path, List.of(2));
+        try {
+            readSecretAsString(kvSecretEngine, path);
+            fail("expected read to fail with 404 after destroying all versions");
+        } catch (VaultClientException e) {
+            assertEquals(404, e.getStatus());
+        }
     }
 
     private static void assertDeleteSecret(VaultKVSecretEngine kvSecretEngine) {

--- a/test-framework/src/main/resources/vault.policy
+++ b/test-framework/src/main/resources/vault.policy
@@ -74,6 +74,14 @@ path "secret-v1/crud" {
   capabilities = ["read", "create", "update", "delete"]
 }
 
+path "secret/data/crud-destroy" {
+  capabilities = ["read", "create", "update"]
+}
+
+path "secret/destroy/crud-destroy" {
+  capabilities = ["update"]
+}
+
 path "totp/*" {
   capabilities = ["read", "create", "update", "delete", "list"]
 }


### PR DESCRIPTION
Fixes #77

Exposes the kv v2 [destroy](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#destroy-secret-versions) operation on the high-level KV engine API (the low-level client already supported it via `destroySecretVersions`):

- `VaultKVSecretReactiveEngine.destroySecret(alias, path, versions)` + default-mount overload
- `VaultKVSecretEngine.destroySecret(path, versions)` (blocking wrapper)
- `KvV2` delegates to the client's `destroySecretVersions`; `KvV1` fails with `UnsupportedOperationException` since destroy only exists in kv v2 (v1 deletes are already permanent, and silently ignoring the versions argument would be misleading)

Tests (run against the Vault testcontainer):
- `VaultITCase#destroySecret` (kv v2): destroying a non-current version leaves the current version readable; destroying the current version makes reads return 404. Test policy gained entries for `secret/data/crud-destroy` and `secret/destroy/crud-destroy`.
- `VaultKv1ITCase#destroySecretV1NotSupported` (kv v1): asserts `UnsupportedOperationException`.

Note: destroy permanently removes version data but not the path metadata; fully erasing the path would be Vault's *delete metadata* operation, which could be a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)