### PR TITLE
Support fetching the username from KV secrets in credentials provider

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-vault.adoc
@@ -623,7 +623,7 @@ a| [[quarkus-vault_quarkus-vault-credentials-provider-credentials-provider-kv-pa
 
 [.description]
 --
-A path in vault kv store, where we will find the kv-key.
+A path in vault kv store, where we will find the kv-password-key and the kv-username-key.
 <p>
 One of `database-credentials-role` or `kv-path` needs to be defined. not both.
 <p>
@@ -639,25 +639,47 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-vault_quarkus-vault-credentials-provider-credentials-provider-kv-key]]`link:#quarkus-vault_quarkus-vault-credentials-provider-credentials-provider-kv-key[quarkus.vault.credentials-provider."credentials-provider".kv-key]`
+a| [[quarkus-vault_quarkus-vault-credentials-provider-credentials-provider-kv-password-key]]`link:#quarkus-vault_quarkus-vault-credentials-provider-credentials-provider-kv-password-key[quarkus.vault.credentials-provider."credentials-provider".kv-password-key]`
 
 
 [.description]
 --
-Key name to search in vault path `kv-path`. The value for that key is the credential.
+Key name to search in vault path `kv-path` for the password credential. The value for that key is the password.
 <p>
-`kv-key` should not be defined if `kv-path` is not.
+`kv-password-key` should not be defined if `kv-path` is not.
 <p>
 see <a href="https://www.vaultproject.io/docs/secrets/kv/index.html">KV Secrets Engine</a>
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_CREDENTIALS_PROVIDER__CREDENTIALS_PROVIDER__KV_KEY+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_CREDENTIALS_PROVIDER__CREDENTIALS_PROVIDER__KV_PASSWORD_KEY+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_VAULT_CREDENTIALS_PROVIDER__CREDENTIALS_PROVIDER__KV_KEY+++`
+Environment variable: `+++QUARKUS_VAULT_CREDENTIALS_PROVIDER__CREDENTIALS_PROVIDER__KV_PASSWORD_KEY+++`
 endif::add-copy-button-to-env-var[]
---|string 
+--|string
 |`password`
+
+
+a| [[quarkus-vault_quarkus-vault-credentials-provider-credentials-provider-kv-username-key]]`link:#quarkus-vault_quarkus-vault-credentials-provider-credentials-provider-kv-username-key[quarkus.vault.credentials-provider."credentials-provider".kv-username-key]`
+
+
+[.description]
+--
+Key name to search in vault path `kv-path` for the username credential. The value for that key is the username.
+If the key is not present in the secret, no username is returned by the credentials provider.
+<p>
+`kv-username-key` should not be defined if `kv-path` is not.
+<p>
+see <a href="https://www.vaultproject.io/docs/secrets/kv/index.html">KV Secrets Engine</a>
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_VAULT_CREDENTIALS_PROVIDER__CREDENTIALS_PROVIDER__KV_USERNAME_KEY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_VAULT_CREDENTIALS_PROVIDER__CREDENTIALS_PROVIDER__KV_USERNAME_KEY+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|`username`
 
 
 h|[[quarkus-vault_quarkus-vault-enterprise-vault-enterprise]]link:#quarkus-vault_quarkus-vault-enterprise-vault-enterprise[Vault Enterprise]

--- a/docs/modules/ROOT/pages/vault-datasource.adoc
+++ b/docs/modules/ROOT/pages/vault-datasource.adoc
@@ -196,7 +196,9 @@ quarkus.vault.credentials-provider.mydatabase.kv-path=myapps/vault-quickstart/db
 ----
 
 This defines a credentials provider `mydatabase` that will fetch the password from key `password`
-at path `myapps/vault-quickstart/db`.
+at path `myapps/vault-quickstart/db`. The keys used to look up the password and the username in the
+Vault secret can be changed with `kv-password-key` (defaults to `password`) and `kv-username-key`
+(defaults to `username`).
 
 The credentials provider can now be used in the datasource configuration, in place of the `password`
 property:
@@ -208,6 +210,15 @@ quarkus.datasource.db-kind = postgresql
 quarkus.datasource.username = sarah
 quarkus.datasource.credentials-provider = mydatabase
 quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5432/mydatabase
+----
+
+If the Vault secret contains a `username` key (or the key configured with `kv-username-key`), the
+credentials provider will return the username as well, allowing you to drop the
+`quarkus.datasource.username` property and manage both credentials in Vault:
+
+[source,bash, subs=attributes+]
+----
+vault kv put secret/myapps/vault-quickstart/db username=sarah password=connor
 ----
 
 Recompile, start and test the `gift-count` endpoint. You should see `0` again.

--- a/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
+++ b/integration-tests/vault/src/test/java/io/quarkus/vault/VaultITCase.java
@@ -96,7 +96,16 @@ public class VaultITCase {
     @Test
     public void credentialsProvider() {
         Map<String, String> staticCredentials = credentialsProvider.getCredentials("static");
-        assertEquals("{" + PASSWORD_PROPERTY_NAME + "=" + DB_PASSWORD + "}", staticCredentials.toString());
+        assertEquals(DB_PASSWORD, staticCredentials.get(PASSWORD_PROPERTY_NAME));
+        assertEquals("postgres", staticCredentials.get(USER_PROPERTY_NAME));
+
+        Map<String, String> explicitKeysCredentials = credentialsProvider.getCredentials("static-explicit-keys");
+        assertEquals(DB_PASSWORD, explicitKeysCredentials.get(PASSWORD_PROPERTY_NAME));
+        assertEquals("postgres", explicitKeysCredentials.get(USER_PROPERTY_NAME));
+
+        Map<String, String> deprecatedKvKeyCredentials = credentialsProvider.getCredentials("static-deprecated-kv-key");
+        assertEquals(DB_PASSWORD, deprecatedKvKeyCredentials.get(PASSWORD_PROPERTY_NAME));
+        assertEquals("postgres", deprecatedKvKeyCredentials.get(USER_PROPERTY_NAME));
 
         Map<String, String> dynamicCredentials = credentialsProvider.getCredentials("dynamic");
         String username = dynamicCredentials.get(USER_PROPERTY_NAME);

--- a/integration-tests/vault/src/test/resources/application-vault.properties
+++ b/integration-tests/vault/src/test/resources/application-vault.properties
@@ -12,6 +12,11 @@ my-fooList=${fooList}
 my-fooMap=${fooMap}
 
 quarkus.vault.credentials-provider.static.kv-path=config
+quarkus.vault.credentials-provider.static-explicit-keys.kv-path=config
+quarkus.vault.credentials-provider.static-explicit-keys.kv-password-key=password
+quarkus.vault.credentials-provider.static-explicit-keys.kv-username-key=username
+quarkus.vault.credentials-provider.static-deprecated-kv-key.kv-path=config
+quarkus.vault.credentials-provider.static-deprecated-kv-key.kv-key=password
 quarkus.vault.credentials-provider.dynamic.database-credentials-role=mydbrole
 
 # upsert

--- a/runtime/src/main/java/io/quarkus/vault/runtime/VaultCredentialsProvider.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/VaultCredentialsProvider.java
@@ -56,14 +56,19 @@ public class VaultCredentialsProvider implements CredentialsProvider {
         }
 
         if (config.kvPath().isPresent()) {
+            String kvPasswordKey = config.kvKey().orElseGet(config::kvPasswordKey);
             var val = vaultKVSecretEngine.readSecretJson(config.kvPath().get());
             if (val == null) {
                 throw new VaultException(
-                        "unable to retrieve credential " + config.kvKey() + " from path " + config.kvPath().get());
+                        "unable to retrieve credential " + kvPasswordKey + " from path " + config.kvPath().get());
             }
-            String password = String.valueOf(val.get(config.kvKey()));
+            String password = String.valueOf(val.get(kvPasswordKey));
             Map<String, String> result = new HashMap<>();
             result.put(PASSWORD_PROPERTY_NAME, password);
+            Object username = val.get(config.kvUsernameKey());
+            if (username != null) {
+                result.put(USER_PROPERTY_NAME, String.valueOf(username));
+            }
             return result;
         }
 

--- a/runtime/src/main/java/io/quarkus/vault/runtime/config/CredentialsProviderConfig.java
+++ b/runtime/src/main/java/io/quarkus/vault/runtime/config/CredentialsProviderConfig.java
@@ -62,7 +62,7 @@ public interface CredentialsProviderConfig {
     String credentialsRequestPath();
 
     /**
-     * A path in vault kv store, where we will find the kv-key.
+     * A path in vault kv store, where we will find the kv-password-key and the kv-username-key.
      * <p>
      * One of `database-credentials-role` or `kv-path` needs to be defined. not both.
      * <p>
@@ -79,10 +79,36 @@ public interface CredentialsProviderConfig {
      * <p>
      * see <a href="https://www.vaultproject.io/docs/secrets/kv/index.html">KV Secrets Engine</a>
      *
+     * @deprecated Use `kv-password-key`
+     * @asciidoclet
+     */
+    @Deprecated(since = "4.9")
+    Optional<String> kvKey();
+
+    /**
+     * Key name to search in vault path `kv-path` for the password credential. The value for that key is the password.
+     * <p>
+     * `kv-password-key` should not be defined if `kv-path` is not.
+     * <p>
+     * see <a href="https://www.vaultproject.io/docs/secrets/kv/index.html">KV Secrets Engine</a>
+     *
      * @asciidoclet
      */
     @WithDefault(PASSWORD_PROPERTY_NAME)
-    String kvKey();
+    String kvPasswordKey();
+
+    /**
+     * Key name to search in vault path `kv-path` for the username credential. The value for that key is the username.
+     * If the key is not present in the secret, no username is returned by the credentials provider.
+     * <p>
+     * `kv-username-key` should not be defined if `kv-path` is not.
+     * <p>
+     * see <a href="https://www.vaultproject.io/docs/secrets/kv/index.html">KV Secrets Engine</a>
+     *
+     * @asciidoclet
+     */
+    @WithDefault("username")
+    String kvUsernameKey();
 
     @Override
     String toString();

--- a/test-framework/src/main/resources/cred-provider.json
+++ b/test-framework/src/main/resources/cred-provider.json
@@ -1,4 +1,5 @@
 {
   "password": "bar",
+  "username": "postgres",
   "mynull": null
 }


### PR DESCRIPTION
Fixes #102

Implements the approach proposed in https://github.com/quarkiverse/quarkus-vault/issues/102#issuecomment-1476620417 and https://github.com/quarkiverse/quarkus-vault/issues/102#issuecomment-1476636841:

- `quarkus.vault.credentials-provider."name".kv-key` is deprecated and its type changed to `Optional` (as discussed in the issue, this allows detecting whether it was explicitly set)
- new `kv-password-key` configuration, defaulting to `password`
- new `kv-username-key` configuration, defaulting to `username`

When the username key is present in the KV secret, `VaultCredentialsProvider` now returns it under the standard `user` property, so consuming extensions (e.g. Agroal) can fetch both the username and the password from Vault and `quarkus.datasource.username` can be dropped, as documented in the [Quarkus credentials provider guide](https://quarkus.io/guides/credentials-provider). Secrets without a username key behave exactly as before.

For backward compatibility, `kv-key`, when set, takes precedence over `kv-password-key`.

Testing:
- `VaultITCase.credentialsProvider` now covers three variants: default keys, explicit `kv-password-key`/`kv-username-key`, and the deprecated `kv-key`
- the shared `cred-provider.json` test fixture now contains a `username` entry, which makes the existing `vault-agroal` static datasource IT exercise username-from-Vault end-to-end against PostgreSQL
- `integration-tests/vault` and `integration-tests/vault-agroal` pass locally

Docs: the datasource guide documents the new keys and the username-in-Vault setup; the generated config reference was updated in sync with the javadoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)