### PR TITLE
Skip patch updates for software.amazon.awssdk:bom in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>quarkiverse/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["software.amazon.awssdk:bom"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Change la configuration Renovate pour `software.amazon.awssdk:bom` afin qu'elle ne se déclenche que sur les versions **majeures** et **mineures** (les mises à jour de type `patch` sont désactivées).

🤖 Generated with [Claude Code](https://claude.com/claude-code)